### PR TITLE
fix: better error loading of char data

### DIFF
--- a/src/defaultCharDataLoader.js
+++ b/src/defaultCharDataLoader.js
@@ -4,17 +4,24 @@
 const VERSION = '1';
 const getCharDataUrl = (char) => `https://cdn.jsdelivr.net/npm/hanzi-writer-data@${VERSION}/${char}.json`;
 
-module.exports = (char, onLoad) => {
+module.exports = (char, onLoad, onError) => {
   // load char data from hanziwriter.org cdn (currently hosted on github pages)
   const xhr = new global.XMLHttpRequest();
   if (xhr.overrideMimeType) { // IE 9 and 10 don't seem to support this...
     xhr.overrideMimeType('application/json');
   }
   xhr.open('GET', getCharDataUrl(char), true);
+  xhr.onerror = (event) => {
+    onError(xhr, event);
+  };
   xhr.onreadystatechange = () => {
     // TODO: error handling
-    if (xhr.readyState === 4 && xhr.status === 200) {
+    if (xhr.readyState !== 4) return;
+
+    if (xhr.status === 200) {
       onLoad(JSON.parse(xhr.responseText));
+    } else if (onError) {
+      onError(xhr);
     }
   };
   xhr.send(null);


### PR DESCRIPTION
The user-defined function is now given a reject callback to trigger error
conditions while loading new character data. Please note that the
running code (not the user-defined function) is also given a chance to
reject the promise (and thus trigger the calling of the error callback)
when it receives a second loading request before the current one is
finished.

This should fix the issues with the error being reported only on next call 
if user-defined function doesn't handle errors itself correctly.

Please note that it doesn't provide a radical change of the API of the user defined function as I suggested in an open issue #41 ... and thus should remain mostly compatible with any custom made user function.