### PR TITLE
fix: provide a ``HanziWriter.cancelAnimation()`` to stop correctly al…

### DIFF
--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -118,7 +118,12 @@ Quiz.prototype._getNextStroke = function() {
 
 // hide the caracter
 Quiz.prototype._setupCharacter = function() {
-  this._animator.animate(animation => this._characterRenderer.hide(animation));
+  this._animator.animate(animation => {
+    if (this._characterRenderer) {
+      return this._characterRenderer.hide(animation);
+    }
+    return Promise.reject();
+  });
 };
 
 module.exports = Quiz;

--- a/src/renderers/CharacterRenderer.js
+++ b/src/renderers/CharacterRenderer.js
@@ -57,7 +57,8 @@ CharacterRenderer.prototype.animate = function(animation) {
   if (!animation.isActive()) return null;
   let renderChain = this.hide(animation);
   this.strokeRenderers.forEach((strokeRenderer, index) => {
-    if (index > 0) renderChain = renderChain.then(() => timeout(this.options.delayBetweenStrokes));
+    if (index > 0) renderChain = renderChain.then(() => timeout(
+      this.options.delayBetweenStrokes, () => (!animation.isActive())));
     renderChain = renderChain.then(() => strokeRenderer.animate(animation));
   });
   return renderChain;

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,10 +59,23 @@ function average(arr) {
   return sum / arr.length;
 }
 
-function timeout(duration = 0) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, duration);
+function timeout(duration = 0, ...predicates) {
+  const startTime = new Date().getTime();
+  const timeoutPromise = new Promise((resolve, reject) => {
+    const timeoutCounter = () => {
+      if (predicates.find((pred) => pred())) {
+        // canceling timeout because of predicate
+        return resolve();
+      }
+      const now = new Date().getTime();
+      if (now - startTime > duration) {
+        return resolve();
+      }
+      setTimeout(timeoutCounter, 5);
+    };
+    timeoutCounter();
   });
+  return timeoutPromise;
 }
 
 function isMSBrowser() {


### PR DESCRIPTION
…l animations.

For several reason, animation where hard to stop:
- no general ``HanziWriter.cancelAnimation()`` was provided, this is
  fixed, and the cancellation process is a complex one due to the many
  queues and hidden callbacks hanging after promises.
- timeout function where used here and there in animation chains
  and would not check if the animation was canceled, inducing delays
  as they would not quit before completion.
- the looping mechanism did not check for animation stop neither.

The ``timeout`` function was expanded to allow any number of predicates
to be checked every 5ms for early cancellation of the timeout.

``cancelAnimation()`` will also return a promise and ensure that the animation are
stopped whenever the promise is resolved.