### PR TITLE
fixing partial opacity and cancelation regressions

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -213,8 +213,7 @@ HanziWriter.prototype._loadCharacterData = function(char) {
 };
 
 HanziWriter.prototype._withData = function(func) {
-  this._withDataPromise = this._withDataPromise.then(func);
-  return this._withDataPromise;
+  return this._withDataPromise.then(func);
 };
 
 HanziWriter.prototype._setupListeners = function() {

--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -51,7 +51,7 @@ Quiz.prototype.endUserStroke = function() {
     this._userStrokeRenderer = null;
 
     if (isMatch) {
-      this._handleSuccess(nextStroke, animation);
+      promises.push(this._handleSuccess(nextStroke, animation));
     } else {
       this._handleFailure();
       if (this._numRecentMistakes >= this._quizOptions.showHintAfterMisses) {

--- a/src/renderers/StrokeRenderer.js
+++ b/src/renderers/StrokeRenderer.js
@@ -97,6 +97,7 @@ StrokeRenderer.prototype.show = function(animation) {
   }
   const tween = new svg.StyleTween(this.path, 'opacity', 1, {
     duration: this.options.strokeFadeDuration,
+    ensureEndStyle: true,
   });
   animation.registerSvgAnimation(tween);
   return tween.start();
@@ -105,6 +106,7 @@ StrokeRenderer.prototype.show = function(animation) {
 StrokeRenderer.prototype.hide = function(animation) {
   const tween = new svg.StyleTween(this.path, 'opacity', 0, {
     duration: this.options.strokeFadeDuration,
+    ensureEndStyle: true,
   });
   animation.registerSvgAnimation(tween);
   return tween.start();

--- a/src/svg.js
+++ b/src/svg.js
@@ -93,6 +93,8 @@ function StyleTween(elm, style, endValue, options = {}) {
   this._elm = elm;
   this._style = style;
   this._endValue = endValue;
+  // ensureEndStyle is if the tween is canceled early, should elm style be set immediately to endValue?
+  this._ensureEndStyle = options.ensureEndStyle;
 }
 inherits(StyleTween, Tween);
 
@@ -102,6 +104,13 @@ StyleTween.prototype.start = function() {
     return Promise.resolve();
   }
   return StyleTween.super_.prototype.start.call(this);
+};
+
+StyleTween.prototype.finish = function() {
+  if (this._isActive && this._ensureEndStyle) {
+    this._elm.style[this._style] = this._endValue;
+  }
+  return StyleTween.super_.prototype.finish.call(this);
 };
 
 // -------- CANVAS CLASS --------


### PR DESCRIPTION
This PR fixes 2 regressions 
- A regression from #35 which causes multiple calls to any animation methods like `animate()` or `hide()` or `show()` before the previous command completed to stack one after another rather than immediately ending the previous animation and replacing it.
- A regression from #24 which causes cancelled opacity animations to end up in a partially opaque state.