### PR TITLE
fixing bug loading a new character while looping

### DIFF
--- a/src/Animator.js
+++ b/src/Animator.js
@@ -10,9 +10,13 @@ Animator.prototype.animate = function(func, options = {}) {
 };
 
 Animator.prototype._setupAnimation = function(options) {
-  if (this._lastAnimation) this._lastAnimation.cancel();
+  this.cancel();
   this._lastAnimation = new Animation(options);
   return this._lastAnimation;
+};
+
+Animator.prototype.cancel = function() {
+  if (this._lastAnimation) this._lastAnimation.cancel();
 };
 
 module.exports = Animator;

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -122,6 +122,7 @@ HanziWriter.prototype.animateCharacter = function(options = {}) {
 };
 HanziWriter.prototype.loopCharacterAnimation = function(options = {}) {
   const animateForever = (animation) => {
+    if (!animation.isActive()) return null;
     const cascadedOpts = assign({}, this._options, options);
     const delayBetweenLoops = cascadedOpts.delayBetweenLoops;
     const animatePromise = this._characterRenderer.animate(animation);
@@ -165,6 +166,7 @@ HanziWriter.prototype.cancelQuiz = function() {
 HanziWriter.prototype.setCharacter = function(char) {
   this.cancelQuiz();
   this._char = char;
+  this._animator.cancel();
   if (this._positionerRenderer) this._positionerRenderer.destroy();
   if (this._characterRenderer) this._characterRenderer.destroy();
   if (this._outlineRenderer) this._outlineRenderer.destroy();


### PR DESCRIPTION
This fixes a bug where if you load a new character while a character animation is looping, it will either throw an error or continue looping when the next character loads. Pointed out by @vaab in https://github.com/chanind/hanzi-writer/issues/50.