### PR TITLE
No auto retry load

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "hanzi-writer-data": "^1.0.0",
     "jest-cli": "^22.2.1",
     "lolex": "^2.3.2",
+    "nise": "^1.2.5",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -196,15 +196,8 @@ HanziWriter.prototype._fillWidthAndHeight = function(options) {
 
 HanziWriter.prototype._withData = function(func) {
   // if this._loadingManager.loadingFailed, then loading failed before this method was called
-  // Try reloading again and see if it helps
   if (this._loadingManager.loadingFailed) {
-    this.setCharacter(this._char);
-    return Promise.resolve().then(() => {
-      // check loadingFailed again just in case setCharacter fails synchronously
-      if (!this._loadingManager.loadingFailed) {
-        return this._withData(func);
-      }
-    });
+    throw Error('Failed to load character data. Call setCharacter and try again.');
   }
   return this._withDataPromise.then(() => {
     if (!this._loadingManager.loadingFailed) {

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -46,7 +46,7 @@ describe('HanziWriter', () => {
       expect(onLoadCharDataError.mock.calls[0][0]).toBe('reasons');
     });
 
-    it('tries reloading when calling an animatable method after loading failure', async () => {
+    it('throws when calling an animatable method after loading failure', async () => {
       document.body.innerHTML = '<div id="target"></div>';
 
       const onLoadCharDataError = jest.fn();
@@ -58,11 +58,10 @@ describe('HanziWriter', () => {
       });
 
       await writer._withDataPromise;
-      await writer.showCharacter();
+      expect(() => writer.showCharacter()).toThrow();
 
-      expect(onLoadCharDataError.mock.calls.length).toBe(2);
-      expect(onLoadCharDataError.mock.calls[0][0]).toBe('reasons');
-      expect(onLoadCharDataError.mock.calls[1][0]).toBe('reasons');
+      expect(onLoadCharDataError).toHaveBeenCalledTimes(1);
+      expect(onLoadCharDataError).toHaveBeenCalledWith('reasons');
     });
 
     it('throws an error on loading fauire if onLoadCharDataError is not provided', async () => {

--- a/src/__tests__/defaultCharDataLoader-test.js
+++ b/src/__tests__/defaultCharDataLoader-test.js
@@ -9,8 +9,8 @@ let requests;
 beforeEach(() => {
   requests = [];
   xhr = fakeXhr.useFakeXMLHttpRequest();
-  xhr.onCreate = function (xhr) {
-    requests.push(xhr);
+  xhr.onCreate = function(req) {
+    requests.push(req);
   };
 });
 
@@ -29,7 +29,7 @@ describe('defaultCharDataLoader', () => {
     expect(requests.length).toBe(1);
     expect(requests[0].url).toBe('https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/人.json');
 
-    requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(ren));
+    requests[0].respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(ren));
 
     expect(onError).not.toHaveBeenCalled();
     expect(onLoad).toHaveBeenCalledTimes(1);
@@ -45,7 +45,7 @@ describe('defaultCharDataLoader', () => {
     expect(requests.length).toBe(1);
     expect(requests[0].url).toBe('https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/Q.json');
 
-    requests[0].respond(404, { "Content-Type": "text/plain" }, "Couldn't find the requested file /Q.json in hanzi-writer-data.");
+    requests[0].respond(404, { 'Content-Type': 'text/plain' }, "Couldn't find the requested file /Q.json in hanzi-writer-data.");
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onLoad).not.toHaveBeenCalled();

--- a/src/__tests__/defaultCharDataLoader-test.js
+++ b/src/__tests__/defaultCharDataLoader-test.js
@@ -1,0 +1,67 @@
+const fakeXhr = require('nise').fakeXhr;
+const ren = require('hanzi-writer-data/人.json');
+const defaultCharDataLoader = require('../defaultCharDataLoader');
+
+
+let xhr;
+let requests;
+
+beforeEach(() => {
+  requests = [];
+  xhr = fakeXhr.useFakeXMLHttpRequest();
+  xhr.onCreate = function (xhr) {
+    requests.push(xhr);
+  };
+});
+
+afterEach(() => {
+  xhr.restore();
+});
+
+
+describe('defaultCharDataLoader', () => {
+  it('loads char data from the jsdelivr CDN', () => {
+    const onLoad = jest.fn();
+    const onError = jest.fn();
+
+    defaultCharDataLoader('人', onLoad, onError);
+
+    expect(requests.length).toBe(1);
+    expect(requests[0].url).toBe('https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/人.json');
+
+    requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(ren));
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(onLoad).toHaveBeenCalledTimes(1);
+    expect(onLoad).toHaveBeenCalledWith(ren);
+  });
+
+  it('calls onError if a non-200 response is returned', () => {
+    const onLoad = jest.fn();
+    const onError = jest.fn();
+
+    defaultCharDataLoader('Q', onLoad, onError);
+
+    expect(requests.length).toBe(1);
+    expect(requests[0].url).toBe('https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/Q.json');
+
+    requests[0].respond(404, { "Content-Type": "text/plain" }, "Couldn't find the requested file /Q.json in hanzi-writer-data.");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onLoad).not.toHaveBeenCalled();
+  });
+
+  it('calls onError if a network error occurs', () => {
+    const onLoad = jest.fn();
+    const onError = jest.fn();
+
+    defaultCharDataLoader('人', onLoad, onError);
+
+    expect(requests.length).toBe(1);
+
+    requests[0].error();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onLoad).not.toHaveBeenCalled();
+  });
+});

--- a/src/defaultCharDataLoader.js
+++ b/src/defaultCharDataLoader.js
@@ -5,7 +5,6 @@ const VERSION = '2.0';
 const getCharDataUrl = (char) => `https://cdn.jsdelivr.net/npm/hanzi-writer-data@${VERSION}/${char}.json`;
 
 module.exports = (char, onLoad, onError) => {
-  let onErrorCalled = false
   // load char data from hanziwriter.org cdn (currently hosted on github pages)
   const xhr = new global.XMLHttpRequest();
   if (xhr.overrideMimeType) { // IE 9 and 10 don't seem to support this...
@@ -13,10 +12,7 @@ module.exports = (char, onLoad, onError) => {
   }
   xhr.open('GET', getCharDataUrl(char), true);
   xhr.onerror = (event) => {
-    if (!onErrorCalled) {
-      onErrorCalled = true;
-      onError(xhr, event);
-    }
+    onError(xhr, event);
   };
   xhr.onreadystatechange = () => {
     // TODO: error handling
@@ -24,8 +20,7 @@ module.exports = (char, onLoad, onError) => {
 
     if (xhr.status === 200) {
       onLoad(JSON.parse(xhr.responseText));
-    } else if (onError && !onErrorCalled) {
-      onErrorCalled = true;
+    } else if (xhr.status !== 0 && onError) {
       onError(xhr);
     }
   };

--- a/src/defaultCharDataLoader.js
+++ b/src/defaultCharDataLoader.js
@@ -5,6 +5,7 @@ const VERSION = '2.0';
 const getCharDataUrl = (char) => `https://cdn.jsdelivr.net/npm/hanzi-writer-data@${VERSION}/${char}.json`;
 
 module.exports = (char, onLoad, onError) => {
+  let onErrorCalled = false
   // load char data from hanziwriter.org cdn (currently hosted on github pages)
   const xhr = new global.XMLHttpRequest();
   if (xhr.overrideMimeType) { // IE 9 and 10 don't seem to support this...
@@ -12,7 +13,10 @@ module.exports = (char, onLoad, onError) => {
   }
   xhr.open('GET', getCharDataUrl(char), true);
   xhr.onerror = (event) => {
-    onError(xhr, event);
+    if (!onErrorCalled) {
+      onErrorCalled = true;
+      onError(xhr, event);
+    }
   };
   xhr.onreadystatechange = () => {
     // TODO: error handling
@@ -20,7 +24,8 @@ module.exports = (char, onLoad, onError) => {
 
     if (xhr.status === 200) {
       onLoad(JSON.parse(xhr.responseText));
-    } else if (onError) {
+    } else if (onError && !onErrorCalled) {
+      onErrorCalled = true;
       onError(xhr);
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,12 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -3351,6 +3357,10 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -3805,6 +3815,10 @@ jsx-ast-utils@^2.0.1:
   dependencies:
     array-includes "^3.0.3"
 
+just-extend@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
@@ -4212,6 +4226,16 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+nise@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.5.tgz#a143371b65014b6807d3a6e6b4556063f3a53363"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^1.1.27"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -4576,6 +4600,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -5123,6 +5153,10 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 sane@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-2.3.0.tgz#3f3df584abf69e63d4bb74f0f8c42468e4d7d46b"
@@ -5614,6 +5648,10 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR removes the auto-retry in `_withData` as discussed with @vaab in #42. It also fixes a bug where `onError` is called twice in case of network failure using the default data loader.