### PR TITLE
fixing character highlight bug on second quiz

### DIFF
--- a/src/__tests__/Quiz-test.js
+++ b/src/__tests__/Quiz-test.js
@@ -85,6 +85,31 @@ describe('Quiz', () => {
         expect(renderState.state.character.main.strokes[strokeNum].opacity).toBe(0);
       });
     });
+
+    it('sets all highlight stroke opacities to 0', async () => {
+      const renderState = createRenderState();
+      renderState.updateState({
+        character: {
+          highlight: {
+            opacity: 0,
+            strokes: {
+              0: { opacity: 1 },
+              1: { opacity: 1 },
+            },
+          },
+        },
+      });
+
+      const quiz = new Quiz(char, renderState, new Positioner());
+      quiz.startQuiz(Object.assign({}, opts));
+      clock.tick(1000);
+      await resolvePromises();
+
+      expect(renderState.state.character.highlight.opacity).toBe(1);
+      Object.keys(renderState.state.character.main.strokes).forEach(strokeNum => {
+        expect(renderState.state.character.highlight.strokes[strokeNum].opacity).toBe(0);
+      });
+    });
   });
 
   describe('startUserStroke', () => {

--- a/src/quizActions.js
+++ b/src/quizActions.js
@@ -5,9 +5,13 @@ const { objRepeat } = require('./utils');
 const startQuiz = (character, fadeDuration) => {
   return characterActions.hideCharacter('main', character, fadeDuration)
     .concat([
+      new Mutation('character.highlight', {
+        opacity: 1,
+        strokes: objRepeat({ opacity: 0, force: true }, character.strokes.length),
+      }),
       new Mutation('character.main', {
         opacity: 1,
-        strokes: objRepeat({ opacity: 0 }, character.strokes.length),
+        strokes: objRepeat({ opacity: 0, force: true }, character.strokes.length),
       }),
     ]);
 };


### PR DESCRIPTION
This PR fixes a bug where the whole character becomes highlighted when the users restarts a quiz after first finishing a quiz successfully. The stroke highlight opacities were not being reset properly before.