### PR TITLE
Rounded path strings

### DIFF
--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -3,12 +3,13 @@ const UserStroke = require('./models/UserStroke');
 const {callIfExists, counter} = require('./utils');
 const quizActions = require('./quizActions');
 const svg = require('./svg');
+const geometry = require('./geometry');
 const characterActions = require('./characterActions');
 
 
 const getDrawnPath = (userStroke) => ({
   pathString: svg.getPathString(userStroke.externalPoints),
-  points: userStroke.points,
+  points: userStroke.points.map(point => geometry.round(point)),
 });
 
 

--- a/src/__tests__/Quiz-test.js
+++ b/src/__tests__/Quiz-test.js
@@ -428,5 +428,33 @@ describe('Quiz', () => {
       await resolvePromises();
       expect(renderState.state.character.highlight.opacity).toBe(0);
     });
+
+    it('rounds drawn path data', async () => {
+      strokeMatches.mockImplementation(() => true);
+
+      const renderState = createRenderState();
+      const quiz = new Quiz(char, renderState, new Positioner());
+      const onCorrectStroke = jest.fn();
+      quiz.startQuiz(Object.assign({}, opts, { onCorrectStroke }));
+      clock.tick(1000);
+      await resolvePromises();
+
+      quiz.startUserStroke({x: 10.93234, y: 20.4567978});
+      quiz.endUserStroke();
+
+      await resolvePromises();
+      expect(onCorrectStroke).toHaveBeenCalledTimes(1);
+      expect(onCorrectStroke).toHaveBeenLastCalledWith({
+        character: '人',
+        mistakesOnStroke: 0,
+        strokeNum: 0,
+        strokesRemaining: 1,
+        totalMistakes: 0,
+        drawnPath: {
+          pathString: 'M 10.9 20.5',
+          points: [{x: 15.9, y: 25.5}],
+        },
+      });
+    });
   });
 });

--- a/src/__tests__/svg-test.js
+++ b/src/__tests__/svg-test.js
@@ -19,5 +19,14 @@ describe('svg', () => {
       ];
       expect(svg.getPathString(points, true)).toEqual('M 0 0 L 5 0 L 5 2Z');
     });
+
+    it('rounds points to 1 decimal point', () => {
+      const points = [
+        {x: 0.11113, y: 0.991212},
+        {x: 5.4565, y: 0.923},
+        {x: 5.4456, y: 2},
+      ];
+      expect(svg.getPathString(points, true)).toEqual('M 0.1 1 L 5.5 0.9 L 5.4 2Z');
+    });
   });
 });

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -2,6 +2,13 @@ const subtract = (p1, p2) => ({x: p1.x - p2.x, y: p1.y - p2.y});
 const magnitude = (point) => Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
 const distance = (point1, point2) => magnitude(subtract(point1, point2));
 const equals = (point1, point2) => point1.x === point2.x && point1.y === point2.y;
+const round = (point, precision = 1) => {
+  const multiplier = precision * 10;
+  return {
+    x: Math.round(multiplier * point.x) / multiplier,
+    y: Math.round(multiplier * point.y) / multiplier,
+  };
+};
 
 const cosineSimilarity = (point1, point2) => {
   const rawDotProduct = point1.x * point2.x + point1.y * point2.y;
@@ -37,6 +44,7 @@ const filterParallelPoints = (points) => {
 };
 
 module.exports = {
+  round,
   equals,
   distance,
   subtract,

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,3 +1,6 @@
+const { round } = require('./geometry');
+
+
 function createElm(elmType) {
   return global.document.createElementNS('http://www.w3.org/2000/svg', elmType);
 }
@@ -11,12 +14,12 @@ function attrs(elm, attrsMap) {
 }
 
 function getPathString(points, close = false) {
-  const start = points[0];
+  const start = round(points[0]);
   const remainingPoints = points.slice(1);
-  const round = (num) => Math.round(num * 10) / 10;
-  let pathString = `M ${round(start.x)} ${round(start.y)}`;
+  let pathString = `M ${start.x} ${start.y}`;
   remainingPoints.forEach(point => {
-    pathString += ` L ${round(point.x)} ${round(point.y)}`;
+    const roundedPoint = round(point);
+    pathString += ` L ${roundedPoint.x} ${roundedPoint.y}`;
   });
   if (close) pathString += 'Z';
   return pathString;

--- a/src/svg.js
+++ b/src/svg.js
@@ -13,9 +13,10 @@ function attrs(elm, attrsMap) {
 function getPathString(points, close = false) {
   const start = points[0];
   const remainingPoints = points.slice(1);
-  let pathString = `M ${start.x} ${start.y}`;
+  const round = (num) => Math.round(num * 10) / 10;
+  let pathString = `M ${round(start.x)} ${round(start.y)}`;
   remainingPoints.forEach(point => {
-    pathString += ` L ${point.x} ${point.y}`;
+    pathString += ` L ${round(point.x)} ${round(point.y)}`;
   });
   if (close) pathString += 'Z';
   return pathString;


### PR DESCRIPTION
This PR rounds the `points` and `pathString` returned in `drawnPath` to 1 decimal place.

fixes #66 