### PR TITLE
fixing a bug where duration: 0 is ignored for show/hide methods

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -71,7 +71,7 @@ HanziWriter.prototype.showCharacter = function(options = {}) {
     this._renderState.run(characterActions.showCharacter(
       'main',
       this._character,
-      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
+      typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -80,7 +80,7 @@ HanziWriter.prototype.hideCharacter = function(options = {}) {
     this._renderState.run(characterActions.hideCharacter(
       'main',
       this._character,
-      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
+      typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -115,7 +115,7 @@ HanziWriter.prototype.showOutline = function(options = {}) {
     this._renderState.run(characterActions.showCharacter(
       'outline',
       this._character,
-      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
+      typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -125,7 +125,7 @@ HanziWriter.prototype.hideOutline = function(options = {}) {
     this._renderState.run(characterActions.hideCharacter(
       'outline',
       this._character,
-      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
+      typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -71,7 +71,7 @@ HanziWriter.prototype.showCharacter = function(options = {}) {
     this._renderState.run(characterActions.showCharacter(
       'main',
       this._character,
-      options.duration || this._options.strokeFadeDuration,
+      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -80,7 +80,7 @@ HanziWriter.prototype.hideCharacter = function(options = {}) {
     this._renderState.run(characterActions.hideCharacter(
       'main',
       this._character,
-      options.duration || this._options.strokeFadeDuration,
+      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -115,7 +115,7 @@ HanziWriter.prototype.showOutline = function(options = {}) {
     this._renderState.run(characterActions.showCharacter(
       'outline',
       this._character,
-      options.duration || this._options.strokeFadeDuration,
+      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
@@ -125,7 +125,7 @@ HanziWriter.prototype.hideOutline = function(options = {}) {
     this._renderState.run(characterActions.hideCharacter(
       'outline',
       this._character,
-      options.duration || this._options.strokeFadeDuration,
+      options.duration >= 0 ? options.duration : this._options.strokeFadeDuration,
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -280,6 +280,35 @@ describe('HanziWriter', () => {
         expect(onComplete).toHaveBeenCalledTimes(1);
         expect(onComplete).toHaveBeenCalledWith({ canceled: false });
       });
+
+      it('resolves immediately if duration: 0 is passed', async () => {
+        document.body.innerHTML = '<div id="target"></div>';
+        const writer = new HanziWriter('target', '人', {
+          showCharacter: true,
+          showOutline: true,
+          charDataLoader,
+        });
+        await writer._withDataPromise;
+
+        let isResolved = false;
+        let resolvedVal;
+        const onComplete = jest.fn();
+
+        writer[`hide${methodLabel}`]({ onComplete, duration: 0 }).then(result => {
+          isResolved = true;
+          resolvedVal = result;
+        });
+
+        expect(isResolved).toBe(false);
+
+        await resolvePromises();
+
+        expect(writer._renderState.state.character[stateLabel].opacity).toBe(0);
+        expect(isResolved).toBe(true);
+        expect(resolvedVal).toEqual({ canceled: false });
+        expect(onComplete).toHaveBeenCalledTimes(1);
+        expect(onComplete).toHaveBeenCalledWith({ canceled: false });
+      });
     });
 
     describe(`show${methodLabel}`, () => {
@@ -329,6 +358,34 @@ describe('HanziWriter', () => {
         const onComplete = jest.fn();
 
         writer[`show${methodLabel}`]({ onComplete }).then(result => {
+          isResolved = true;
+          resolvedVal = result;
+        });
+
+        expect(isResolved).toBe(false);
+
+        await resolvePromises();
+
+        expect(writer._renderState.state.character[stateLabel].opacity).toBe(1);
+        expect(isResolved).toBe(true);
+        expect(resolvedVal).toEqual({ canceled: false });
+        expect(onComplete).toHaveBeenCalledTimes(1);
+        expect(onComplete).toHaveBeenCalledWith({ canceled: false });
+      });
+
+      it('resolves immediately if duration: 0 is passed', async () => {
+        document.body.innerHTML = '<div id="target"></div>';
+        const writer = new HanziWriter('target', '人', {
+          [`show${methodLabel}`]: false,
+          charDataLoader,
+        });
+        await writer._withDataPromise;
+
+        let isResolved = false;
+        let resolvedVal;
+        const onComplete = jest.fn();
+
+        writer[`show${methodLabel}`]({ onComplete, duration: 0 }).then(result => {
           isResolved = true;
           resolvedVal = result;
         });


### PR DESCRIPTION
Settings `duration: 0` when calling a show/hide method, ex `showCharacter({ duration: 0 })` should cause the method to complete immediately. However, this was broken because 0 is also considered falsy. This PR fixes this by explicitly checking `typeof options.duration === 'number'` instead.