### PR TITLE
Static data helpers

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -64,36 +64,6 @@ function HanziWriter(element, character, options = {}) {
   this._quiz = null;
 }
 
-// --- Static Public API --- //
-
-let lastLoadingManager = null;
-let lastLoadingOptions = null;
-
-HanziWriter.loadCharacterData = (character, options = {}) => {
-  let loadingManager;
-  if (lastLoadingManager && lastLoadingOptions === options) {
-    loadingManager = lastLoadingManager;
-  } else {
-    loadingManager = new LoadingManager(options);
-  }
-  lastLoadingManager = loadingManager;
-  lastLoadingOptions = options;
-  return loadingManager.loadCharData(character);
-};
-
-HanziWriter.getScalingTransform = (width, height, padding = 0) => {
-  const positioner = new Positioner({ width, height, padding });
-  return {
-    x: positioner.getXOffset(),
-    y: positioner.getYOffset(),
-    scale: positioner.getScale(),
-    transform: trim(`
-translate(${positioner.getXOffset()}, ${positioner.getHeight() - positioner.getYOffset()})
-scale(${positioner.getScale()}, ${-1 * positioner.getScale()})
-    `),
-  };
-};
-
 // ------ public API ------ //
 
 HanziWriter.prototype.showCharacter = function(options = {}) {
@@ -289,6 +259,35 @@ HanziWriter.prototype._getTouchPoint = function(evt) {
   return {x, y};
 };
 
+// --- Static Public API --- //
+
+let lastLoadingManager = null;
+let lastLoadingOptions = null;
+
+HanziWriter.loadCharacterData = (character, options = {}) => {
+  let loadingManager;
+  if (lastLoadingManager && lastLoadingOptions === options) {
+    loadingManager = lastLoadingManager;
+  } else {
+    loadingManager = new LoadingManager(options);
+  }
+  lastLoadingManager = loadingManager;
+  lastLoadingOptions = options;
+  return loadingManager.loadCharData(character);
+};
+
+HanziWriter.getScalingTransform = (width, height, padding = 0) => {
+  const positioner = new Positioner({ width, height, padding });
+  return {
+    x: positioner.getXOffset(),
+    y: positioner.getYOffset(),
+    scale: positioner.getScale(),
+    transform: trim(`
+translate(${positioner.getXOffset()}, ${positioner.getHeight() - positioner.getYOffset()})
+scale(${positioner.getScale()}, ${-1 * positioner.getScale()})
+    `),
+  };
+};
 
 // set up window.HanziWriter if we're in the browser
 if (typeof global.window !== 'undefined') {

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -283,9 +283,9 @@ HanziWriter.getScalingTransform = (width, height, padding = 0) => {
     y: positioner.getYOffset(),
     scale: positioner.getScale(),
     transform: trim(`
-translate(${positioner.getXOffset()}, ${positioner.getHeight() - positioner.getYOffset()})
-scale(${positioner.getScale()}, ${-1 * positioner.getScale()})
-    `),
+      translate(${positioner.getXOffset()}, ${positioner.getHeight() - positioner.getYOffset()})
+      scale(${positioner.getScale()}, ${-1 * positioner.getScale()})
+    `).replace(/\s+/g, ' '),
   };
 };
 

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -269,7 +269,7 @@ HanziWriter.loadCharacterData = (character, options = {}) => {
   if (lastLoadingManager && lastLoadingOptions === options) {
     loadingManager = lastLoadingManager;
   } else {
-    loadingManager = new LoadingManager(options);
+    loadingManager = new LoadingManager(assign({}, defaultOptions, options));
   }
   lastLoadingManager = loadingManager;
   lastLoadingOptions = options;

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -7,7 +7,7 @@ const svg = require('./svg');
 const defaultCharDataLoader = require('./defaultCharDataLoader');
 const LoadingManager = require('./LoadingManager');
 const characterActions = require('./characterActions');
-const { assign, callIfExists } = require('./utils');
+const { assign, callIfExists, trim } = require('./utils');
 
 
 const defaultOptions = {
@@ -63,6 +63,36 @@ function HanziWriter(element, character, options = {}) {
   this._setupListeners();
   this._quiz = null;
 }
+
+// --- Static Public API --- //
+
+let lastLoadingManager = null;
+let lastLoadingOptions = null;
+
+HanziWriter.loadCharacterData = (character, options = {}) => {
+  let loadingManager;
+  if (lastLoadingManager && lastLoadingOptions === options) {
+    loadingManager = lastLoadingManager;
+  } else {
+    loadingManager = new LoadingManager(options);
+  }
+  lastLoadingManager = loadingManager;
+  lastLoadingOptions = options;
+  return loadingManager.loadCharData(character);
+};
+
+HanziWriter.getScalingTransform = (width, height, padding = 0) => {
+  const positioner = new Positioner({ width, height, padding });
+  return {
+    x: positioner.getXOffset(),
+    y: positioner.getYOffset(),
+    scale: positioner.getScale(),
+    transform: trim(`
+translate(${positioner.getXOffset()}, ${positioner.getHeight() - positioner.getYOffset()})
+scale(${positioner.getScale()}, ${-1 * positioner.getScale()})
+    `),
+  };
+};
 
 // ------ public API ------ //
 
@@ -156,7 +186,7 @@ HanziWriter.prototype.setCharacter = function(char) {
 
     const charDataParser = new CharDataParser();
     this._character = charDataParser.generateCharacter(char, pathStrings);
-    this._positioner = new Positioner(this._character, this._options);
+    this._positioner = new Positioner(this._options);
     this._hanziWriterRenderer = new HanziWriterRenderer(this._character, this._positioner);
     this._renderState = new RenderState(this._character, this._options, (nextState) => {
       this._hanziWriterRenderer.render(nextState);

--- a/src/Positioner.js
+++ b/src/Positioner.js
@@ -1,5 +1,7 @@
-function Positioner(character, options) {
-  this._character = character;
+// All makemeahanzi characters have the same bounding box
+const CHARACTER_BOUNDS = [{x: 0, y: -124}, {x: 1024, y: 900}];
+
+function Positioner(options) {
   this._options = options;
   this._calculateScaleAndOffset();
 }
@@ -16,7 +18,7 @@ Positioner.prototype.getScale = function() { return this._scale; };
 Positioner.prototype.getHeight = function() { return this._options.height; };
 
 Positioner.prototype._calculateScaleAndOffset = function() {
-  const bounds = this._character.getBounds();
+  const bounds = CHARACTER_BOUNDS;
   const preScaledWidth = bounds[1].x - bounds[0].x;
   const preScaledHeight = bounds[1].y - bounds[0].y;
   const effectiveWidth = this._options.width - 2 * this._options.padding;

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -530,6 +530,53 @@ describe('HanziWriter', () => {
     });
   });
 
+  describe('loadCharacterData', () => {
+    it('calls onLoadCharDataError if provided on loading failure', async () => {
+      const onLoadCharDataError = jest.fn();
+      const loadingPromise = HanziWriter.loadCharacterData('人', {
+        onLoadCharDataError,
+        charDataLoader: () => Promise.reject('reasons'),
+      });
+
+      await loadingPromise;
+
+      expect(onLoadCharDataError.mock.calls.length).toBe(1);
+      expect(onLoadCharDataError.mock.calls[0][0]).toBe('reasons');
+    });
+
+    it('throws an error on loading fauire if onLoadCharDataError is not provided', async () => {
+      const loadingPromise = HanziWriter.loadCharacterData('人', {
+        charDataLoader: (char, onComplete, onErr) => {
+          onErr(new Error('reasons'));
+        },
+      });
+
+      await expect(loadingPromise).rejects.toThrow(new Error('reasons'));
+    });
+
+    it('returns the character data in a promise on success', async () => {
+      const loadingPromise = HanziWriter.loadCharacterData('人', {
+        charDataLoader: (char, onComplete, onErr) => ren,
+      });
+
+      const result = await loadingPromise;
+      expect(result).toBe(ren);
+    });
+
+    it('returns the character data in onLoadCharDataSuccess if provided', async () => {
+      const onLoadCharDataSuccess = jest.fn();
+      const loadingPromise = HanziWriter.loadCharacterData('人', {
+        onLoadCharDataSuccess,
+        charDataLoader: (char, onComplete, onErr) => ren,
+      });
+
+      await loadingPromise;
+
+      expect(onLoadCharDataSuccess.mock.calls.length).toBe(1);
+      expect(onLoadCharDataSuccess.mock.calls[0][0]).toBe(ren);
+    });
+  });
+
   describe('option defaults', () => {
     it('works with legacy strokeAnimationDuration and strokeHighlightDuration if present', () => {
       const writer = new HanziWriter('target', '人', {

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -577,6 +577,26 @@ describe('HanziWriter', () => {
     });
   });
 
+  describe('getScalingTransform', () => {
+    it('returns an object with info that can be used for scaling a makemeahanzi character in SVG', () => {
+      expect(HanziWriter.getScalingTransform(100, 120, 10)).toEqual({
+        scale: 0.078125,
+        transform: 'translate(10, 90.3125) scale(0.078125, -0.078125)',
+        x: 10,
+        y: 29.6875,
+      });
+    });
+
+    it('uses 0 as the default padding', () => {
+      expect(HanziWriter.getScalingTransform(100, 100)).toEqual({
+        scale: 0.09765625,
+        transform: 'translate(0, 87.890625) scale(0.09765625, -0.09765625)',
+        x: 0,
+        y: 12.109375,
+      });
+    });
+  });
+
   describe('option defaults', () => {
     it('works with legacy strokeAnimationDuration and strokeHighlightDuration if present', () => {
       const writer = new HanziWriter('target', '人', {

--- a/src/__tests__/Positioner-test.js
+++ b/src/__tests__/Positioner-test.js
@@ -8,7 +8,7 @@ const char = new CharDataParser().generateCharacter('人', ren);
 
 describe('Positioner', () => {
   it('calculates scale and offset to transform characters to fix in the box on screen', () => {
-    const positioner = new Positioner(char, { width: 400, height: 400, padding: 20 });
+    const positioner = new Positioner({ width: 400, height: 400, padding: 20 });
 
     expect(positioner.getXOffset()).toBe(20);
     expect(positioner.getYOffset()).toBe(63.59375);
@@ -17,7 +17,7 @@ describe('Positioner', () => {
   });
 
   it('converts points from the external reference frame to the character reference frame', () => {
-    const positioner = new Positioner(char, { width: 400, height: 400, padding: 20 });
+    const positioner = new Positioner({ width: 400, height: 400, padding: 20 });
     expect(positioner.convertExternalPoint({x: 30, y: 50})).toEqual({x: 28.444444444444443, y: 814.6666666666666});
   });
 });

--- a/src/__tests__/Positioner-test.js
+++ b/src/__tests__/Positioner-test.js
@@ -1,9 +1,5 @@
-const ren = require('hanzi-writer-data/人.json');
 const Positioner = require('../Positioner');
 const CharDataParser = require('../CharDataParser');
-
-
-const char = new CharDataParser().generateCharacter('人', ren);
 
 
 describe('Positioner', () => {

--- a/src/__tests__/Positioner-test.js
+++ b/src/__tests__/Positioner-test.js
@@ -1,5 +1,4 @@
 const Positioner = require('../Positioner');
-const CharDataParser = require('../CharDataParser');
 
 
 describe('Positioner', () => {

--- a/src/models/Character.js
+++ b/src/models/Character.js
@@ -3,8 +3,4 @@ function Character(symbol, strokes) {
   this.strokes = strokes;
 }
 
-Character.prototype.getBounds = function() {
-  return [{x: 0, y: -124}, {x: 1024, y: 900}];
-};
-
 module.exports = Character;

--- a/src/renderers/__tests__/HanziWriterRenderer-test.js
+++ b/src/renderers/__tests__/HanziWriterRenderer-test.js
@@ -7,7 +7,7 @@ const CharDataParser = require('../../CharDataParser');
 
 
 const char = new CharDataParser().generateCharacter('人', ren);
-const positioner = new Positioner(char, {
+const positioner = new Positioner({
   width: 100,
   height: 100,
   padding: 10,

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,8 @@ function timeout(duration = 0) {
   });
 }
 
+const trim = (string) => string.replace(/^\s+/, '').replace(/\s+$/, '');
+
 // return a new array-like object with int keys where each key is item
 // ex: objRepeat({x: 8}, 3) === {0: {x: 8}, 1: {x: 8}, 2: {x: 8}}
 const objRepeat = (item, times) => {
@@ -105,4 +107,5 @@ module.exports = {
   performanceNow,
   requestAnimationFrame,
   timeout,
+  trim,
 };


### PR DESCRIPTION
Adding 2 static helper to make it easier to work directly with hanzi writer data in SVG.

The following 2 methods are added: 
- `HanziWriter.loadCharacterData(char, options = {})` loads and parses character data, by default from the hanzi writer cdn.
- `HanziWriter.getScalingTransform(width, height, padding = 0)` returns an object containing scaling info for use in an svg G element to render the SVG paths from makemeahanzi at the specified size.