### PR TITLE
Using SVG matrix transforms to determine mouse points where possible

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -57,6 +57,9 @@ const defaultOptions = {
 
 function HanziWriter(element, character, options = {}) {
   this._canvas = svg.Canvas.init(element);
+  if (this._canvas.svg.createSVGPoint) {
+    this._pt = this._canvas.svg.createSVGPoint();
+  }
   this._options = this._assignOptions(options);
   this._loadingManager = new LoadingManager(this._options);
   this.setCharacter(character);
@@ -248,11 +251,28 @@ HanziWriter.prototype._forwardToQuiz = function(method, ...args) {
 };
 
 HanziWriter.prototype._getMousePoint = function(evt) {
+  if (this._pt) {
+    this._pt.x = evt.clientX;
+    this._pt.y = evt.clientY;
+    const localPt = this._pt.matrixTransform(this._canvas.svg.getScreenCTM().inverse());
+    return {x: localPt.x, y: localPt.y};
+  }
+  // fallback in case SVG matrix transforms aren't supported
   const box = this._canvas.svg.getBoundingClientRect();
-  return {x: evt.clientX - box.left, y: evt.clientY - box.top};
+  const x = evt.clientX - box.left;
+  const y = evt.clientY - box.top;
+  return {x, y};
 };
 
 HanziWriter.prototype._getTouchPoint = function(evt) {
+
+  if (this._pt) {
+    this._pt.x = evt.touches[0].clientX;
+    this._pt.y = evt.touches[0].clientY;
+    const localPt = this._pt.matrixTransform(this._canvas.svg.getScreenCTM().inverse());
+    return {x: localPt.x, y: localPt.y};
+  }
+  // fallback in case SVG matrix transforms aren't supported
   const box = this._canvas.svg.getBoundingClientRect();
   const x = evt.touches[0].clientX - box.left;
   const y = evt.touches[0].clientY - box.top;


### PR DESCRIPTION
This PR implements mouse/touch tracking using SVG matrix transforms as suggested in #83, with a fallback to the old method if not supported.

- [x] tested in Chrome
- [x] tested in Safari
- [x] tested in Firefox
- [ ] tested in IE

closes #83