### PR TITLE
Simplifying constructor, but keeping backwards compatibility

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -56,7 +56,6 @@ const defaultOptions = {
 };
 
 function HanziWriter(...args) {
-  this._hasRunInit = false;
   if (args.length > 0) {
     let character;
     let options = {};
@@ -70,7 +69,7 @@ function HanziWriter(...args) {
         options = args[1];
       }
     }
-    this.init(element, options);
+    this._init(element, options);
     if (character) {
       this.setCharacter(character);
     }
@@ -79,22 +78,7 @@ function HanziWriter(...args) {
 
 // ------ public API ------ //
 
-HanziWriter.prototype.init = function(element, options) {
-  if (this._hasRunInit) throw new Error('init() was already called. Cannot run init() twice.');
-  this._hasRunInit = true;
-  this._canvas = svg.Canvas.init(element, options.width, options.height);
-  if (this._canvas.svg.createSVGPoint) {
-    this._pt = this._canvas.svg.createSVGPoint();
-  }
-  this._options = this._assignOptions(options);
-  this._loadingManager = new LoadingManager(this._options);
-  this._setupListeners();
-  this._quiz = null;
-  return this;
-};
-
 HanziWriter.prototype.showCharacter = function(options = {}) {
-  if (!this._hasRunInit) throw new Error('you must run init() before running setCharacter()');
   return this._withData(() => (
     this._renderState.run(characterActions.showCharacter(
       'main',
@@ -196,6 +180,18 @@ HanziWriter.prototype.setCharacter = function(char) {
 };
 
 // ------------- //
+
+HanziWriter.prototype._init = function(element, options) {
+  this._canvas = svg.Canvas.init(element, options.width, options.height);
+  if (this._canvas.svg.createSVGPoint) {
+    this._pt = this._canvas.svg.createSVGPoint();
+  }
+  this._options = this._assignOptions(options);
+  this._loadingManager = new LoadingManager(this._options);
+  this._setupListeners();
+  this._quiz = null;
+  return this;
+};
 
 HanziWriter.prototype._assignOptions = function(options) {
   const mergedOptions = assign({}, defaultOptions, options);
@@ -306,8 +302,7 @@ HanziWriter.prototype._getTouchPoint = function(evt) {
 // --- Static Public API --- //
 
 HanziWriter.create = (element, character, options = {}) => {
-  const writer = new HanziWriter();
-  writer.init(element, options);
+  const writer = new HanziWriter(element, options);
   writer.setCharacter(character);
   return writer;
 };

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -19,10 +19,53 @@ describe('HanziWriter', () => {
   });
 
   describe('constructor', () => {
-    it('loads data and builds an instance in a dom element', async () => {
+    it('can optionally run init() if element and options are passed in', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+
+      const writer = new HanziWriter('target', { charDataLoader });
+      await writer.setCharacter('人');
+
+      expect(document.querySelectorAll('#target svg').length).toBe(1);
+      const svg = document.querySelector('#target svg');
+      expect(svg.childNodes.length).toBe(2);
+      expect(svg.childNodes[0].nodeName).toBe('defs');
+      expect(svg.childNodes[1].nodeName).toBe('g');
+      // the characters are repeated 3 times - one for outline, character, and highlight
+      expect(svg.childNodes[1].childNodes.length).toBe(3);
+      svg.childNodes[1].childNodes.forEach(charNode => {
+        expect(charNode.nodeName).toBe('g');
+        // 2 strokes per character
+        expect(charNode.childNodes.length).toBe(2);
+      });
+    });
+
+    it('[deprecated] loads data and builds an instance in a dom element', async () => {
       document.body.innerHTML = '<div id="target"></div>';
 
       const writer = new HanziWriter('target', '人', { charDataLoader });
+
+      await writer._withDataPromise;
+
+      expect(document.querySelectorAll('#target svg').length).toBe(1);
+      const svg = document.querySelector('#target svg');
+      expect(svg.childNodes.length).toBe(2);
+      expect(svg.childNodes[0].nodeName).toBe('defs');
+      expect(svg.childNodes[1].nodeName).toBe('g');
+      // the characters are repeated 3 times - one for outline, character, and highlight
+      expect(svg.childNodes[1].childNodes.length).toBe(3);
+      svg.childNodes[1].childNodes.forEach(charNode => {
+        expect(charNode.nodeName).toBe('g');
+        // 2 strokes per character
+        expect(charNode.childNodes.length).toBe(2);
+      });
+    });
+  });
+
+  describe('HanziWriter.create', () => {
+    it('loads data and builds an instance in a dom element', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+
+      const writer = HanziWriter.create('target', '人', { charDataLoader });
 
       await writer._withDataPromise;
 


### PR DESCRIPTION
As discussed in #55, this PR simplifies the behavior of `new HanziWriter()` while maintaining backwards compatibility. This PR thus allows setup via the following methods:

1. `writer = new HanziWriter('target', '人', options)` original behavior. This will now `console.warn` that this is deprecated.
2. `writer = HanziWriter.create('target', '人', options)` Helper which mimics old constructor behavior
3. `writer = new HanziWriter('target', options); writer.setCharacter('人');`
4. `writer = new HanziWriter(); writer.init('target', options); writer.setCharacter('人');`

I'm leaning towards removing option `[4]` above, since it's a bit awkward with needing to call `writer.init('target', options)` after `new HanziWriter()` but before `setCharacter()`, which seems a bit verbose. But it's maybe also the most technically correct as the constructor does literally nothing then? thoughts @vaab and @Mikurox?

This is a large enough change that it probably makes sense to put it into the `1.0` release

closes #55 
