### PR TITLE
Update colors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
     "no-for-of-loops"
   ],
   "rules": {
-    "id-length": [2, {"exceptions": ["x", "y", "i", "j"]}],
+    "id-length": [2, {"exceptions": ["x", "y", "i", "j", "r", "g", "b", "a"]}],
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     "max-len":[0],
     "no-loop-func": [0],

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "max-len":[0],
     "no-loop-func": [0],
     "no-plusplus": [0],
+    "no-continue": [0],
     "no-prototype-builtins": [0],
     "no-underscore-dangle": [0],
     "jsx-a11y/href-no-hash": [0],

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -148,18 +148,20 @@ HanziWriter.prototype.updateColors = function(newColors, options = {}) {
     // stroke color must go before radical color, since if radicalColor is null we use strokeColor instead
     const colorProps = ['strokeColor', 'radicalColor', 'highlightColor', 'outlineColor', 'drawingColor'];
     const duration = typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration;
-    const mutationChains = [];
+    const mappedColors = {};
     colorProps.forEach(colorProp => {
       if (colorProp in newColors) {
         let newColorVal = newColors[colorProp];
         if (colorProp === 'radicalColor' && !newColorVal) {
           newColorVal = this._options.strokeColor;
         }
-        mutationChains.push(characterActions.updateColor(colorProp, colorStringToVals(newColorVal), duration));
+        mappedColors[colorProp] = colorStringToVals(newColorVal);
         this._options[colorProp] = newColors[colorProp];
       }
     });
-    return this._renderState.runAll(mutationChains);
+    return this._renderState
+      .run(characterActions.updateColors(mappedColors, duration))
+      .then(res => callIfExists(options.onComplete, res));
   });
 };
 

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -147,14 +147,18 @@ HanziWriter.prototype.updateColor = function(colorName, colorVal, options = {}) 
   return this._withData(() => {
     const duration = typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration;
     let fixedColorVal = colorVal;
+    // If we're removing radical color, tween it to the stroke color
     if (colorName === 'radicalColor' && !colorVal) {
       fixedColorVal = this._options.strokeColor;
     }
     const mappedColor = colorStringToVals(fixedColorVal);
     this._options[colorName] = colorVal;
-    return this._renderState
-      .run(characterActions.updateColor(colorName, mappedColor, duration))
-      .then(res => callIfExists(options.onComplete, res));
+    let mutation = characterActions.updateColor(colorName, mappedColor, duration);
+    // make sure to set radicalColor back to null after the transition finishes if val == null
+    if (colorName === 'radicalColor' && !colorVal) {
+      mutation = mutation.concat(characterActions.updateColor(colorName, null, 0));
+    }
+    return this._renderState.run(mutation).then(res => callIfExists(options.onComplete, res));
   });
 };
 

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -143,6 +143,24 @@ HanziWriter.prototype.hideOutline = function(options = {}) {
   ));
 };
 
+['strokeColor', 'radicalColor', 'highlightColor', 'outlineColor', 'drawingColor']
+HanziWriter.prototype.updateColors = function(newColors, options = {}) {
+  return this._withData(() => {
+    const mutationChains = [];
+    const duration = typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration;
+    if ('strokeColor' in newColors) {
+      mutationChains.push(characterActions.updateColor('main', 'strokeColor', newColors.strokeColor))
+    }
+    this._renderState.run(characterActions.hideCharacter(
+      'outline',
+      this._character,
+      typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration,
+    )).then(res => callIfExists(options.onComplete, res))
+  });
+};
+
+
+
 HanziWriter.prototype.quiz = function(quizOptions = {}) {
   this._withData(() => {
     this.cancelQuiz();

--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -143,24 +143,17 @@ HanziWriter.prototype.hideOutline = function(options = {}) {
   ));
 };
 
-HanziWriter.prototype.updateColors = function(newColors, options = {}) {
+HanziWriter.prototype.updateColor = function(colorName, colorVal, options = {}) {
   return this._withData(() => {
-    // stroke color must go before radical color, since if radicalColor is null we use strokeColor instead
-    const colorProps = ['strokeColor', 'radicalColor', 'highlightColor', 'outlineColor', 'drawingColor'];
     const duration = typeof options.duration === 'number' ? options.duration : this._options.strokeFadeDuration;
-    const mappedColors = {};
-    colorProps.forEach(colorProp => {
-      if (colorProp in newColors) {
-        let newColorVal = newColors[colorProp];
-        if (colorProp === 'radicalColor' && !newColorVal) {
-          newColorVal = this._options.strokeColor;
-        }
-        mappedColors[colorProp] = colorStringToVals(newColorVal);
-        this._options[colorProp] = newColors[colorProp];
-      }
-    });
+    let fixedColorVal = colorVal;
+    if (colorName === 'radicalColor' && !colorVal) {
+      fixedColorVal = this._options.strokeColor;
+    }
+    const mappedColor = colorStringToVals(fixedColorVal);
+    this._options[colorName] = colorVal;
     return this._renderState
-      .run(characterActions.updateColors(mappedColors, duration))
+      .run(characterActions.updateColor(colorName, mappedColor, duration))
       .then(res => callIfExists(options.onComplete, res));
   });
 };

--- a/src/RenderState.js
+++ b/src/RenderState.js
@@ -1,4 +1,4 @@
-const { copyAndMergeDeep } = require('./utils');
+const { copyAndMergeDeep, colorStringToVals } = require('./utils');
 
 function RenderState(character, options, onStateChange) {
   this._onStateChange = onStateChange;
@@ -7,22 +7,22 @@ function RenderState(character, options, onStateChange) {
     options: {
       drawingFadeDuration: options.drawingFadeDuration,
       drawingWidth: options.drawingWidth,
-      drawingColor: options.drawingColor,
+      drawingColor: colorStringToVals(options.drawingColor),
+      strokeColor: colorStringToVals(options.strokeColor),
+      outlineColor: colorStringToVals(options.outlineColor),
+      radicalColor: colorStringToVals(options.radicalColor || options.strokeColor),
+      highlightColor: colorStringToVals(options.highlightColor),
     },
     character: {
       main: {
-        strokeColor: options.strokeColor,
-        radicalColor: options.radicalColor,
         opacity: options.showCharacter ? 1 : 0,
         strokes: {},
       },
       outline: {
-        strokeColor: options.outlineColor,
         opacity: options.showOutline ? 1 : 0,
         strokes: {},
       },
       highlight: {
-        strokeColor: options.highlightColor,
         opacity: 1,
         strokes: {},
       },

--- a/src/RenderState.js
+++ b/src/RenderState.js
@@ -51,6 +51,10 @@ RenderState.prototype.updateState = function(stateChanges) {
   this.state = nextState;
 };
 
+RenderState.prototype.runAll = function(mutationChains, options = {}) {
+  return Promise.all(mutationChains.map(chain => this.run(chain, options)));
+};
+
 RenderState.prototype.run = function(mutations, options = {}) {
   const scopes = mutations.map(mut => mut.scope).filter(x => x);
   this.cancelMutations(scopes);

--- a/src/RenderState.js
+++ b/src/RenderState.js
@@ -51,10 +51,6 @@ RenderState.prototype.updateState = function(stateChanges) {
   this.state = nextState;
 };
 
-RenderState.prototype.runAll = function(mutationChains, options = {}) {
-  return Promise.all(mutationChains.map(chain => this.run(chain, options)));
-};
-
 RenderState.prototype.run = function(mutations, options = {}) {
   const scopes = mutations.map(mut => mut.scope).filter(x => x);
   this.cancelMutations(scopes);

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -446,6 +446,86 @@ describe('HanziWriter', () => {
     });
   });
 
+  describe('updateColors', () => {
+    it('animates and returns promise that resolves when finished', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+      const writer = new HanziWriter('target', '人', {
+        strokeColor: '#123',
+        outlineColor: '#EEE',
+        charDataLoader,
+      });
+      await writer._withDataPromise;
+
+      let isResolved = false;
+      let resolvedVal;
+      const onComplete = jest.fn();
+
+      writer.updateColors({
+        strokeColor: 'rgba(30, 30, 30, 0.8)',
+        outlineColor: '#CC32AB',
+      }, { onComplete }).then(result => {
+        isResolved = true;
+        resolvedVal = result;
+      });
+
+      await resolvePromises();
+
+      expect(writer._renderState.state.options.strokeColor).toEqual({r: 17, g: 34, b: 51, a: 1});
+      expect(writer._renderState.state.options.outlineColor).toEqual({r: 238, g: 238, b: 238, a: 1});
+      expect(isResolved).toBe(false);
+
+      clock.tick(1000);
+      await resolvePromises();
+
+      expect(writer._renderState.state.options.strokeColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
+      expect(writer._renderState.state.options.outlineColor).toEqual({r: 204, g: 50, b: 171, a: 1});
+
+      expect(isResolved).toBe(true);
+      expect(resolvedVal).toEqual({ canceled: false });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith({ canceled: false });
+    });
+
+    it('uses strokeColor for the tween if radicalColor is set to null', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+      const writer = new HanziWriter('target', '人', {
+        strokeColor: '#123',
+        radicalColor: '#EEE',
+        charDataLoader,
+      });
+      await writer._withDataPromise;
+
+      let isResolved = false;
+      let resolvedVal;
+      const onComplete = jest.fn();
+
+      writer.updateColors({
+        radicalColor: null,
+        strokeColor: 'rgba(30, 30, 30, 0.8)',
+      }, { onComplete }).then(result => {
+        isResolved = true;
+        resolvedVal = result;
+      });
+
+      await resolvePromises();
+
+      expect(writer._renderState.state.options.strokeColor).toEqual({r: 17, g: 34, b: 51, a: 1});
+      expect(writer._renderState.state.options.radicalColor).toEqual({r: 238, g: 238, b: 238, a: 1});
+      expect(isResolved).toBe(false);
+
+      clock.tick(1000);
+      await resolvePromises();
+
+      expect(writer._renderState.state.options.strokeColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
+      expect(writer._renderState.state.options.radicalColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});;
+
+      expect(isResolved).toBe(true);
+      expect(resolvedVal).toEqual({ canceled: false });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledWith({ canceled: false });
+    });
+  });
+
   describe('quiz', () => {
     it('sets up and starts the quiz', async () => {
       document.body.innerHTML = '<div id="target"></div>';

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -493,7 +493,7 @@ describe('HanziWriter', () => {
       let resolvedVal;
       const onComplete = jest.fn();
 
-      writer.updateColor('radicalColor', null, { onComplete }).then(result => {
+      writer.updateColor('radicalColor', null, { onComplete, duration: 1000 }).then(result => {
         isResolved = true;
         resolvedVal = result;
       });
@@ -503,10 +503,16 @@ describe('HanziWriter', () => {
       expect(writer._renderState.state.options.radicalColor).toEqual({r: 238, g: 238, b: 238, a: 1});
       expect(isResolved).toBe(false);
 
-      clock.tick(1000);
+      clock.tick(999);
+      await resolvePromises();
+      expect(writer._renderState.state.options.radicalColor.r).toBeCloseTo(30, 0);
+      expect(writer._renderState.state.options.radicalColor.g).toBeCloseTo(30, 0);
+      expect(writer._renderState.state.options.radicalColor.b).toBeCloseTo(30, 0);
+      expect(writer._renderState.state.options.radicalColor.a).toBeCloseTo(1, 0);
+      clock.tick(10);
       await resolvePromises();
 
-      expect(writer._renderState.state.options.radicalColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
+      expect(writer._renderState.state.options.radicalColor).toBeNull();
 
       expect(isResolved).toBe(true);
       expect(resolvedVal).toEqual({ canceled: false });

--- a/src/__tests__/HanziWriter-test.js
+++ b/src/__tests__/HanziWriter-test.js
@@ -446,12 +446,11 @@ describe('HanziWriter', () => {
     });
   });
 
-  describe('updateColors', () => {
+  describe('updateColor', () => {
     it('animates and returns promise that resolves when finished', async () => {
       document.body.innerHTML = '<div id="target"></div>';
       const writer = new HanziWriter('target', '人', {
         strokeColor: '#123',
-        outlineColor: '#EEE',
         charDataLoader,
       });
       await writer._withDataPromise;
@@ -460,10 +459,7 @@ describe('HanziWriter', () => {
       let resolvedVal;
       const onComplete = jest.fn();
 
-      writer.updateColors({
-        strokeColor: 'rgba(30, 30, 30, 0.8)',
-        outlineColor: '#CC32AB',
-      }, { onComplete }).then(result => {
+      writer.updateColor('strokeColor', 'rgba(30, 30, 30, 0.8)', { onComplete }).then(result => {
         isResolved = true;
         resolvedVal = result;
       });
@@ -471,14 +467,12 @@ describe('HanziWriter', () => {
       await resolvePromises();
 
       expect(writer._renderState.state.options.strokeColor).toEqual({r: 17, g: 34, b: 51, a: 1});
-      expect(writer._renderState.state.options.outlineColor).toEqual({r: 238, g: 238, b: 238, a: 1});
       expect(isResolved).toBe(false);
 
       clock.tick(1000);
       await resolvePromises();
 
       expect(writer._renderState.state.options.strokeColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
-      expect(writer._renderState.state.options.outlineColor).toEqual({r: 204, g: 50, b: 171, a: 1});
 
       expect(isResolved).toBe(true);
       expect(resolvedVal).toEqual({ canceled: false });
@@ -489,7 +483,7 @@ describe('HanziWriter', () => {
     it('uses strokeColor for the tween if radicalColor is set to null', async () => {
       document.body.innerHTML = '<div id="target"></div>';
       const writer = new HanziWriter('target', '人', {
-        strokeColor: '#123',
+        strokeColor: 'rgba(30, 30, 30, 0.8)',
         radicalColor: '#EEE',
         charDataLoader,
       });
@@ -499,25 +493,20 @@ describe('HanziWriter', () => {
       let resolvedVal;
       const onComplete = jest.fn();
 
-      writer.updateColors({
-        radicalColor: null,
-        strokeColor: 'rgba(30, 30, 30, 0.8)',
-      }, { onComplete }).then(result => {
+      writer.updateColor('radicalColor', null, { onComplete }).then(result => {
         isResolved = true;
         resolvedVal = result;
       });
 
       await resolvePromises();
 
-      expect(writer._renderState.state.options.strokeColor).toEqual({r: 17, g: 34, b: 51, a: 1});
       expect(writer._renderState.state.options.radicalColor).toEqual({r: 238, g: 238, b: 238, a: 1});
       expect(isResolved).toBe(false);
 
       clock.tick(1000);
       await resolvePromises();
 
-      expect(writer._renderState.state.options.strokeColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
-      expect(writer._renderState.state.options.radicalColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});;
+      expect(writer._renderState.state.options.radicalColor).toEqual({r: 30, g: 30, b: 30, a: 0.8});
 
       expect(isResolved).toBe(true);
       expect(resolvedVal).toEqual({ canceled: false });

--- a/src/__tests__/RenderState-test.js
+++ b/src/__tests__/RenderState-test.js
@@ -27,12 +27,14 @@ describe('RenderState', () => {
       options: {
         drawingFadeDuration: 300,
         drawingWidth: 4,
-        drawingColor: '#333',
+        drawingColor: {r: 51, g: 51, b: 51, a: 1},
+        strokeColor: {r: 85, g: 85, b: 85, a: 1},
+        radicalColor: {r: 17, g: 34, b: 51, a: 1},
+        highlightColor: {r: 170, g: 170, b: 255, a: 1},
+        outlineColor: {r: 221, g: 221, b: 221, a: 1},
       },
       character: {
         main: {
-          strokeColor: '#555',
-          radicalColor: '#123',
           opacity: 1,
           strokes: {
             0: {
@@ -46,7 +48,6 @@ describe('RenderState', () => {
           },
         },
         outline: {
-          strokeColor: '#DDD',
           opacity: 0,
           strokes: {
             0: {
@@ -60,7 +61,6 @@ describe('RenderState', () => {
           },
         },
         highlight: {
-          strokeColor: '#AAF',
           opacity: 1,
           strokes: {
             0: {

--- a/src/__tests__/utils-test.js
+++ b/src/__tests__/utils-test.js
@@ -71,6 +71,29 @@ describe('utils', () => {
     });
   });
 
+  describe('colorStringToVals', () => {
+    it('parses hex strings into rgba numbers', () => {
+      expect(utils.colorStringToVals('#DDCA1B')).toEqual({r: 221, g: 202, b: 27, a: 1});
+    });
+    it('works with shortened hex numbers too', () => {
+      expect(utils.colorStringToVals('#DC0')).toEqual({r: 221, g: 204, b: 0, a: 1});
+    });
+    it('works with rgb format', () => {
+      expect(utils.colorStringToVals('rgb(10,99,193)')).toEqual({r: 10, g: 99, b: 193, a: 1});
+      expect(utils.colorStringToVals('rgb(10 ,  99 ,  193)')).toEqual({r: 10, g: 99, b: 193, a: 1});
+    });
+    it('works with rgba format', () => {
+      expect(utils.colorStringToVals('rgba(10,99,193, 0.3)')).toEqual({r: 10, g: 99, b: 193, a: 0.3});
+      expect(utils.colorStringToVals('rgba(10 ,  99 ,  193, 0.1)')).toEqual({r: 10, g: 99, b: 193, a: 0.1});
+    });
+    it('ignores capitalization and leading / trailing spaces', () => {
+      expect(utils.colorStringToVals('#dc0  ')).toEqual({r: 221, g: 204, b: 0, a: 1});
+      expect(utils.colorStringToVals(' #dDCa1b')).toEqual({r: 221, g: 202, b: 27, a: 1});
+      expect(utils.colorStringToVals('  RgBa(10 ,  99 ,  193, 0.1) ')).toEqual({r: 10, g: 99, b: 193, a: 0.1});
+      expect(utils.colorStringToVals('RGB(10,99,193)')).toEqual({r: 10, g: 99, b: 193, a: 1});
+    });
+  });
+
   describe('inflate', () => {
     it('inflates the scope into a full object and attaches the obj', () => {
       expect(utils.inflate('bob.jim.joe', {x: 8})).toEqual({

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -26,8 +26,8 @@ const hideCharacter = (charName, character, duration) => {
   ].concat(showStrokes(charName, character, 0));
 };
 
-const updateColor = (charName, colorName, colorVal, duration) => {
-  return [new Mutation(`character.${charName}.${colorName}`, colorVal, { duration, force: true })];
+const updateColor = (colorName, colorVal, duration) => {
+  return [new Mutation(`options.${colorName}`, colorVal, { duration, force: true })];
 };
 
 const animateStroke = (charName, stroke, speed) => {

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -26,8 +26,8 @@ const hideCharacter = (charName, character, duration) => {
   ].concat(showStrokes(charName, character, 0));
 };
 
-const updateColor = (colorName, colorVal, duration) => {
-  return [new Mutation(`options.${colorName}`, colorVal, { duration, force: true })];
+const updateColors = (colors, duration) => {
+  return [new Mutation('options', colors, { duration, force: true })];
 };
 
 const animateStroke = (charName, stroke, speed) => {
@@ -84,5 +84,5 @@ module.exports = {
   animateCharacterLoop,
   animateStroke,
   showStroke,
-  updateColor,
+  updateColors,
 };

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -26,8 +26,8 @@ const hideCharacter = (charName, character, duration) => {
   ].concat(showStrokes(charName, character, 0));
 };
 
-const updateColors = (colors, duration) => {
-  return [new Mutation('options', colors, { duration, force: true })];
+const updateColor = (colorName, colorVal, duration) => {
+  return [new Mutation(`options.${colorName}`, colorVal, { duration })];
 };
 
 const animateStroke = (charName, stroke, speed) => {
@@ -84,5 +84,5 @@ module.exports = {
   animateCharacterLoop,
   animateStroke,
   showStroke,
-  updateColors,
+  updateColor,
 };

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -26,6 +26,10 @@ const hideCharacter = (charName, character, duration) => {
   ].concat(showStrokes(charName, character, 0));
 };
 
+const updateColor = (charName, colorName, colorVal, duration) => {
+  return [new Mutation(`character.${charName}.${colorName}`, colorVal, { duration, force: true })];
+};
+
 const animateStroke = (charName, stroke, speed) => {
   const strokeNum = stroke.strokeNum;
   const duration = (stroke.getLength() + 600) / (3 * speed);
@@ -80,4 +84,5 @@ module.exports = {
   animateCharacterLoop,
   animateStroke,
   showStroke,
+  updateColor,
 };

--- a/src/renderers/CharacterRenderer.js
+++ b/src/renderers/CharacterRenderer.js
@@ -25,13 +25,21 @@ CharacterRenderer.prototype.render = function(props) {
       this._group.style.display = 'initial';
     }
   }
-  for (let i = 0; i < this.strokeRenderers.length; i++) {
-    this.strokeRenderers[i].render({
-      strokeColor: props.strokeColor,
-      radicalColor: props.radicalColor,
-      opacity: props.strokes[i].opacity,
-      displayPortion: props.strokes[i].displayPortion,
-    });
+  const colorsChanged = (
+    !this._oldProps ||
+    props.strokeColor !== this._oldProps.strokeColor ||
+    props.radicalColor !== this._oldProps.radicalColor
+  );
+  if (colorsChanged || props.strokes !== this._oldProps.strokes) {
+    for (let i = 0; i < this.strokeRenderers.length; i++) {
+      if (!colorsChanged && this._oldProps.strokes && props.strokes[i] === this._oldProps.strokes[i]) continue;
+      this.strokeRenderers[i].render({
+        strokeColor: props.strokeColor,
+        radicalColor: props.radicalColor,
+        opacity: props.strokes[i].opacity,
+        displayPortion: props.strokes[i].displayPortion,
+      });
+    }
   }
   this._oldProps = props;
 };

--- a/src/renderers/HanziWriterRenderer.js
+++ b/src/renderers/HanziWriterRenderer.js
@@ -26,9 +26,22 @@ HanziWriterRenderer.prototype.mount = function(canvas) {
 };
 
 HanziWriterRenderer.prototype.render = function(props) {
-  this._outlineCharRenderer.render(props.character.outline);
-  this._mainCharRenderer.render(props.character.main);
-  this._highlightCharRenderer.render(props.character.highlight);
+  this._outlineCharRenderer.render({
+    opacity: props.character.outline.opacity,
+    strokes: props.character.outline.strokes,
+    strokeColor: props.options.outlineColor,
+  });
+  this._mainCharRenderer.render({
+    opacity: props.character.main.opacity,
+    strokes: props.character.main.strokes,
+    strokeColor: props.options.strokeColor,
+    radicalColor: props.options.radicalColor,
+  });
+  this._highlightCharRenderer.render({
+    opacity: props.character.highlight.opacity,
+    strokes: props.character.highlight.strokes,
+    strokeColor: props.options.highlightColor,
+  });
 
   const userStrokes = props.userStrokes || {};
   Object.keys(this._userStrokeRenderers).forEach(userStrokeId => {

--- a/src/renderers/StrokeRenderer.js
+++ b/src/renderers/StrokeRenderer.js
@@ -61,7 +61,8 @@ StrokeRenderer.prototype.render = function(props) {
 
   const color = this._getColor(props);
   if (color !== this._getColor(this._oldProps)) {
-    svg.attrs(this._animationPath, { stroke: color });
+    const {r, g, b, a} = color;
+    svg.attrs(this._animationPath, { stroke: `rgba(${r},${g},${b},${a})` });
   }
 
   if (props.opacity !== this._oldProps.opacity) {

--- a/src/renderers/UserStrokeRenderer.js
+++ b/src/renderers/UserStrokeRenderer.js
@@ -13,9 +13,10 @@ UserStrokeRenderer.prototype.mount = function(canvas) {
 UserStrokeRenderer.prototype.render = function(props) {
   if (props === this._oldProps) return;
   if (props.strokeColor !== this._oldProps.strokeColor || props.strokeWidth !== this._oldProps.strokeWidth) {
+    const {r, g, b, a} = props.strokeColor;
     svg.attrs(this._path, {
       fill: 'none',
-      stroke: props.strokeColor,
+      stroke: `rgba(${r},${g},${b},${a})`,
       'stroke-width': props.strokeWidth,
       'stroke-linecap': 'round',
       'stroke-linejoin': 'round',

--- a/src/renderers/__tests__/CharacterRenderer-test.js
+++ b/src/renderers/__tests__/CharacterRenderer-test.js
@@ -18,7 +18,7 @@ describe('CharacterRenderer', () => {
 
   it('renders a g element and puts strokes inside', () => {
     const props = {
-      strokeColor: '#123',
+      strokeColor: {r: 120, g: 17, b: 101, a: 0.3},
       radicalColor: null,
       strokeWidth: 2,
       opacity: 0.7,
@@ -45,13 +45,13 @@ describe('CharacterRenderer', () => {
     expect(subCanvas.childNodes.length).toBe(2);
     subCanvas.childNodes.forEach(node => {
       expect(node.nodeName).toBe('path');
-      expect(node.getAttribute('stroke')).toBe('#123');
+      expect(node.getAttribute('stroke')).toBe('rgba(120,17,101,0.3)');
     });
   });
 
   it('updates opacity and updates passed-through props', () => {
     const props1 = {
-      strokeColor: '#123',
+      strokeColor: {r: 120, g: 17, b: 101, a: 0.3},
       radicalColor: null,
       strokeWidth: 2,
       opacity: 0.7,
@@ -68,7 +68,7 @@ describe('CharacterRenderer', () => {
     };
 
     const props2 = copyAndMergeDeep(props1, {
-      strokeColor: '#456',
+      strokeColor: {r: 255, g: 255, b: 0, a: 0.1},
       opacity: 0.9,
     });
 
@@ -85,13 +85,13 @@ describe('CharacterRenderer', () => {
     expect(subCanvas.childNodes.length).toBe(2);
     subCanvas.childNodes.forEach(node => {
       expect(node.nodeName).toBe('path');
-      expect(node.getAttribute('stroke')).toBe('#456');
+      expect(node.getAttribute('stroke')).toBe('rgba(255,255,0,0.1)');
     });
   });
 
   it('sets display: none if opacity is 0', () => {
     const props1 = {
-      strokeColor: '#123',
+      strokeColor: {r: 101, g: 101, b: 101, a: 1},
       radicalColor: null,
       strokeWidth: 2,
       opacity: 0,
@@ -108,7 +108,7 @@ describe('CharacterRenderer', () => {
     };
 
     const props2 = copyAndMergeDeep(props1, {
-      strokeColor: '#456',
+      strokeColor: {r: 255, g: 255, b: 0, a: 0.1},
       opacity: 0.9,
     });
 

--- a/src/renderers/__tests__/HanziWriterRenderer-test.js
+++ b/src/renderers/__tests__/HanziWriterRenderer-test.js
@@ -25,7 +25,6 @@ describe('HanziWriterRenderer', () => {
   it('adds and removes user stroke renderers as needed', () => {
     const charProps = {
       opacity: 0.7,
-      strokeColor: '#123',
       strokes: {
         0: {
           opacity: 1,
@@ -42,7 +41,7 @@ describe('HanziWriterRenderer', () => {
       options: {
         strokeWidth: 2,
         drawingWidth: 4,
-        drawingColor: '#456',
+        drawingColor: {r: 255, g: 255, b: 0, a: 0.1},
       },
       character: {
         outline: charProps,
@@ -68,7 +67,7 @@ describe('HanziWriterRenderer', () => {
     expect(userStrokes.length).toBe(1);
     expect(userStrokes[0].getAttribute('opacity')).toBe('0.9');
     expect(userStrokes[0].getAttribute('stroke-width')).toBe('4');
-    expect(userStrokes[0].getAttribute('stroke')).toBe('#456');
+    expect(userStrokes[0].getAttribute('stroke')).toBe('rgba(255,255,0,0.1)');
     expect(userStrokes[0].getAttribute('d')).toBe('M 0 0 L 1 3');
 
     renderer.render(props2);

--- a/src/renderers/__tests__/StrokeRenderer-test.js
+++ b/src/renderers/__tests__/StrokeRenderer-test.js
@@ -17,7 +17,7 @@ describe('StrokeRenderer', () => {
 
   it('renders a path and clipPath', () => {
     const props = {
-      strokeColor: '#123',
+      strokeColor: {r: 12, g: 101, b: 20, a: 0.3},
       radicalColor: null,
       strokeWidth: 2,
       opacity: 0.7,
@@ -35,7 +35,7 @@ describe('StrokeRenderer', () => {
     const maskId = canvas.defs.childNodes[0].getAttribute('id');
     expect(canvas.svg.childNodes.length).toBe(2); // defs and path
     expect(canvas.svg.childNodes[1].nodeName).toBe('path');
-    expect(canvas.svg.childNodes[1].getAttribute('stroke')).toBe('#123');
+    expect(canvas.svg.childNodes[1].getAttribute('stroke')).toBe('rgba(12,101,20,0.3)');
     expect(canvas.svg.childNodes[1].getAttribute('clip-path')).toBe(`url(#${maskId})`);
 
     expect(maskPath).toMatchSnapshot();

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,34 @@ function timeout(duration = 0) {
   });
 }
 
+function colorStringToVals(colorString) {
+  const normalizedColor = colorString.toUpperCase().trim();
+  // based on https://stackoverflow.com/a/21648508
+  if (/^#([A-F0-9]{3}){1,2}$/.test(normalizedColor)) {
+    let hexParts = normalizedColor.substring(1).split('');
+    if (hexParts.length === 3) {
+      hexParts = [hexParts[0], hexParts[0], hexParts[1], hexParts[1], hexParts[2], hexParts[2]];
+    }
+    const hexStr = `${hexParts.join('')}`;
+    return {
+      r: parseInt(hexStr.slice(0, 2), 16),
+      g: parseInt(hexStr.slice(2, 4), 16),
+      b: parseInt(hexStr.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+  const rgbMatch = normalizedColor.match(/^RGBA?\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*(\d*\.?\d+))?\)$/);
+  if (rgbMatch) {
+    return {
+      r: parseInt(rgbMatch[1], 10),
+      g: parseInt(rgbMatch[2], 10),
+      b: parseInt(rgbMatch[3], 10),
+      a: parseFloat(rgbMatch[4] || 1, 10),
+    };
+  }
+  throw new Error(`Invalid color: ${colorString}`);
+}
+
 const trim = (string) => string.replace(/^\s+/, '').replace(/\s+$/, '');
 
 // return a new array-like object with int keys where each key is item
@@ -99,6 +127,7 @@ module.exports = {
   average,
   callIfExists,
   cancelAnimationFrame,
+  colorStringToVals,
   copyAndMergeDeep,
   counter,
   emptyFunc,


### PR DESCRIPTION
Closes #87 

This PR adds an `updateColor(colorName, newValue, options)` method which can be used to tween colors on a running `HanziWriter` instance.