### PR TITLE
adding a writer.animateStroke() method

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -109,6 +109,17 @@ HanziWriter.prototype.animateCharacter = function(options = {}) {
     )).then(res => callIfExists(options.onComplete, res))
   ));
 };
+HanziWriter.prototype.animateStroke = function(strokeNum, options = {}) {
+  this.cancelQuiz();
+  return this._withData(() => (
+    this._renderState.run(characterActions.animateSingleStroke(
+      'main',
+      this._character,
+      strokeNum,
+      this._options.strokeAnimationSpeed,
+    )).then(res => callIfExists(options.onComplete, res))
+  ));
+};
 HanziWriter.prototype.loopCharacterAnimation = function(options = {}) {
   this.cancelQuiz();
   return this._withData(() => (

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -47,6 +47,25 @@ const animateStroke = (charName, stroke, speed) => {
   ];
 };
 
+const animateSingleStroke = (charName, character, strokeNum, speed) => {
+  const mutationStateFunc = (state) => {
+    const curCharState = state.character[charName];
+    const mutationState = {
+      opacity: 1,
+      strokes: {},
+    };
+    for (let i = 0; i < character.strokes.length; i++) {
+      mutationState.strokes[i] = {
+        opacity: curCharState.opacity * curCharState.strokes[i].opacity,
+      };
+    }
+    return mutationState;
+  };
+  return [new Mutation(`character.${charName}`, mutationStateFunc)].concat(
+    animateStroke(charName, character.strokes[strokeNum], speed),
+  );
+};
+
 const showStroke = (charName, strokeNum, duration) => {
   return [
     new Mutation(`character.${charName}.strokes.${strokeNum}`, {
@@ -83,6 +102,7 @@ module.exports = {
   animateCharacter,
   animateCharacterLoop,
   animateStroke,
+  animateSingleStroke,
   showStroke,
   updateColor,
 };


### PR DESCRIPTION
closes #91 

This PR adds a `writer.animateStroke(strokeNum, options = {})` method which can be used to animate a single stroke at a time. It works similar to `writer.animateCharacter(options = {})`, with the same options and similarly returning a promise which resolves when the stroke is finished animating.