### PR TITLE
Fixing safari stroke mask rendering bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 coverage
 .DS_Store
 .sass-cache
+.vscode
 cdn
 _site

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "transform": {
       ".*": "<rootDir>/../babel-jest-processor.js"
     },
-    "testURL": "https://test.com/url",
+    "testURL": "https://test.com/url#tag",
     "rootDir": "src",
     "coverageDirectory": "../coverage/",
     "collectCoverage": true

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "transform": {
       ".*": "<rootDir>/../babel-jest-processor.js"
     },
+    "testURL": "https://test.com/url",
     "rootDir": "src",
     "coverageDirectory": "../coverage/",
     "collectCoverage": true

--- a/src/renderers/StrokeRenderer.js
+++ b/src/renderers/StrokeRenderer.js
@@ -34,7 +34,7 @@ StrokeRenderer.prototype.mount = function(canvas) {
 
   svg.attr(this._strokePath, 'd', this._stroke.path);
   this._animationPath.style.opacity = 0;
-  svg.attr(this._animationPath, 'clip-path', `url(#${maskId})`);
+  svg.attr(this._animationPath, 'clip-path', svg.urlIdRef(maskId));
 
   const extendedMaskPoints = extendStart(filterParallelPoints(this._stroke.points), STROKE_WIDTH / 2);
   svg.attr(this._animationPath, 'd', svg.getPathString(extendedMaskPoints));

--- a/src/renderers/__tests__/StrokeRenderer-test.js
+++ b/src/renderers/__tests__/StrokeRenderer-test.js
@@ -36,7 +36,7 @@ describe('StrokeRenderer', () => {
     expect(canvas.svg.childNodes.length).toBe(2); // defs and path
     expect(canvas.svg.childNodes[1].nodeName).toBe('path');
     expect(canvas.svg.childNodes[1].getAttribute('stroke')).toBe('rgba(12,101,20,0.3)');
-    expect(canvas.svg.childNodes[1].getAttribute('clip-path')).toBe(`url(#${maskId})`);
+    expect(canvas.svg.childNodes[1].getAttribute('clip-path')).toBe(`url(https://test.com/url#${maskId})`);
 
     expect(maskPath).toMatchSnapshot();
   });

--- a/src/strokeMatches.js
+++ b/src/strokeMatches.js
@@ -14,7 +14,7 @@ const AVG_DIST_THRESHOLD = 350; // bigger = more lenient
 const COSINE_SIMILARITY_THRESHOLD = 0; // -1 to 1, smaller = more lenient
 const START_AND_END_DIST_THRESHOLD = 250; // bigger = more lenient
 const FRECHET_THRESHOLD = 0.40; // bigger = more lenient
-const MIN_LEN_THRESHOLD = 0.35; // smalled = more lenient
+const MIN_LEN_THRESHOLD = 0.35; // smaller = more lenient
 
 const startAndEndMatches = function(points, closestStroke, leniency) {
   const startingDist = distance(closestStroke.getStartingPoint(), points[0]);

--- a/src/svg.js
+++ b/src/svg.js
@@ -13,6 +13,15 @@ function attrs(elm, attrsMap) {
   Object.keys(attrsMap).forEach(attrName => attr(elm, attrName, attrsMap[attrName]));
 }
 
+// inspired by https://talk.observablehq.com/t/hanzi-writer-renders-incorrectly-inside-an-observable-notebook-on-a-mobile-browser/1898
+function urlIdRef(id) {
+  let prefix = '';
+  if (global.location && global.location.href) {
+    prefix = global.location.href;
+  }
+  return `url(${prefix}#${id})`;
+}
+
 function getPathString(points, close = false) {
   const start = round(points[0]);
   const remainingPoints = points.slice(1);
@@ -61,4 +70,4 @@ Canvas.init = (elmOrId, width = '100%', height = '100%') => {
   return new Canvas(svg, defs);
 };
 
-module.exports = { createElm, attrs, attr, Canvas, getPathString, removeElm };
+module.exports = { createElm, attrs, attr, Canvas, getPathString, removeElm, urlIdRef };

--- a/src/svg.js
+++ b/src/svg.js
@@ -17,7 +17,7 @@ function attrs(elm, attrsMap) {
 function urlIdRef(id) {
   let prefix = '';
   if (global.location && global.location.href) {
-    prefix = global.location.href;
+    prefix = global.location.href.replace(/#[^#]*$/, '');
   }
   return `url(${prefix}#${id})`;
 }


### PR DESCRIPTION
This PR adds `window.location.href` to the urls in clip masks to fix a bug in mobile Sarafi with relative urls. More details here: https://talk.observablehq.com/t/hanzi-writer-renders-incorrectly-inside-an-observable-notebook-on-a-mobile-browser/1898/2

Thanks @mbostock for figuring this out! (and also for d3 :)

fixes #104 