### PR TITLE
Build UMD package and use a variable-safe library name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,8 +61,8 @@ module.exports = function(grunt) {
         entry: './src/HanziWriter.js',
         output: {
           filename: 'dist/hanzi-writer-lib.js',
-          library: 'hanzi-writer',
-          libraryTarget: 'commonjs2'
+          library: 'hanziWriter',
+          libraryTarget: 'umd'
         }
       }
     },


### PR DESCRIPTION
Hi there!

This PR switches the main `dist` output form commonjs2 to UMD. The effect of this change is that folks would be able to use hanzi-writer with UMD/AMD tools like d3-require and requirejs, and that other people can also use a simple `<script>` tag to include the library on a page. The usage through CommonJS/Node is the same as it was before.