### PR TITLE
fix: calling setCharacter multiple times quickly breaks rendering

### DIFF
--- a/src/LoadingManager.js
+++ b/src/LoadingManager.js
@@ -5,7 +5,6 @@ function LoadingManager(options) {
   this._loadCounter = 0;
   this._options = options;
   this._isLoading = false;
-  this._loadingPromise = null;
 
   // use this to attribute to determine if there was a problem with loading
   this.loadingFailed = false;
@@ -25,7 +24,7 @@ LoadingManager.prototype._debouncedLoad = function(char, count) {
 };
 
 LoadingManager.prototype._setupLoadingPromise = function() {
-  this._loadingPromise = new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     this._resolve = resolve;
     this._reject = reject;
   }).then((data) => {
@@ -48,14 +47,12 @@ LoadingManager.prototype._setupLoadingPromise = function() {
 
 LoadingManager.prototype.loadCharData = function(char) {
   this._loadingChar = char;
-  if (!this._isLoading) {
-    this._setupLoadingPromise();
-  }
+  const promise = this._setupLoadingPromise();
   this.loadingFailed = false;
   this._isLoading = true;
   this._loadCounter++;
   this._debouncedLoad(char, this._loadCounter);
-  return this._loadingPromise;
+  return promise;
 };
 
 module.exports = LoadingManager;

--- a/src/__tests__/LoadingManager-test.js
+++ b/src/__tests__/LoadingManager-test.js
@@ -94,15 +94,21 @@ describe('LoadingManager', () => {
 
       const loadPromise1 = manager.loadCharData('人');
       const loadPromise2 = manager.loadCharData('他');
-      // it should return the same promise for both since loading isn't complete
-      expect(loadPromise1).toBe(loadPromise2);
+      expect(loadPromise1).not.toBe(loadPromise2);
+
+      let hasPromise1Resolved = false;
+      loadPromise1.then(() => {
+        hasPromise1Resolved = true;
+      });
 
       onCompleteFns[0].call(null, ren);
       onCompleteFns[1].call(null, ta);
 
-      const data = await loadPromise1;
+      const data = await loadPromise2;
 
-      // ren should be ignored. It's like it was never requested at all
+      // ren should not resolve, since we requested something else before it finished loading
+      expect(hasPromise1Resolved).toBe(false);
+
       expect(data).toBe(ta);
       expect(onLoadCharDataSuccess.mock.calls.length).toBe(1);
       expect(onLoadCharDataSuccess.mock.calls[0][0]).toBe(ta);


### PR DESCRIPTION
This PR fixes a bug where calling `setCharacter()` multiple times while a character is loading, then calling `setCharacter()` again causes rendering to break.

Thanks @josephjohnston for finding this bug!

fixes #129 
