### PR TITLE
feat: pauseAnimation and resumeAnimation

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -147,6 +147,14 @@ HanziWriter.prototype.loopCharacterAnimation = function(options = {}) {
   ));
 };
 
+HanziWriter.prototype.pauseAnimation = function() {
+  return this._withData(() => this._renderState.pauseAll());
+};
+
+HanziWriter.prototype.resumeAnimation = function() {
+  return this._withData(() => this._renderState.resumeAll());
+};
+
 HanziWriter.prototype.showOutline = function(options = {}) {
   this._options.showOutline = true;
   return this._withData(() => (

--- a/src/Mutation.js
+++ b/src/Mutation.js
@@ -38,8 +38,6 @@ const isAlreadyAtEnd = function(startValues, endValues) {
   return true;
 };
 
-let id = 0;
-
 // from https://github.com/maxwellito/vivus
 const ease = x => -Math.cos(x * Math.PI) / 2 + 0.5;
 
@@ -51,7 +49,6 @@ function Mutation(scope, valuesOrCallable, options = {}) {
   this._pausedDuration = 0;
   this._tickBound = this._tick.bind(this);
   this._startPauseTime = null;
-  this._id = id++;
 }
 
 
@@ -131,15 +128,14 @@ Delay.prototype.pause = function() {
   this._duration = Math.max(0, this._duration - elapsedDelay);
   clearTimeout(this._timeout);
   this._paused = true;
-}
+};
 
 Delay.prototype.resume = function() {
   if (!this._paused) return;
   this._startTime = performanceNow();
   this._timeout = setTimeout(() => this.cancel(), this._duration);
   this._paused = false;
-  
-}
+};
 
 Delay.prototype.run = function() {
   const timeoutPromise = new Promise((resolve) => {

--- a/src/RenderState.js
+++ b/src/RenderState.js
@@ -92,6 +92,20 @@ RenderState.prototype._run = function(mutationChain) {
   });
 };
 
+RenderState.prototype._getActiveMutations = function() {
+  return this._mutationChains.map(chain => {
+    return chain._mutations[chain._index];
+  });
+};
+
+RenderState.prototype.pauseAll = function() {
+  this._getActiveMutations().forEach(mutation => mutation.pause());
+};
+
+RenderState.prototype.resumeAll = function() {
+  this._getActiveMutations().forEach(mutation => mutation.resume());
+};
+
 RenderState.prototype.cancelMutations = function(scopes) {
   this._mutationChains.forEach(chain => {
     chain._scopes.forEach(chainScope => {

--- a/src/__tests__/Mutation-test.js
+++ b/src/__tests__/Mutation-test.js
@@ -178,7 +178,7 @@ describe('Mutation.Delay', () => {
     await Promise.resolve();
 
     expect(isResolved).toBe(false);
-    
+
     delay.resume();
     await Promise.resolve();
 

--- a/src/__tests__/RenderState-test.js
+++ b/src/__tests__/RenderState-test.js
@@ -89,7 +89,7 @@ describe('RenderState', () => {
       renderState.run([
         new Mutation('character.main.opacity', 0.3),
         new Mutation('character.main.opacity', 0.9, { duration: 50 }),
-        new Mutation.Pause(100),
+        new Mutation.Delay(100),
         new Mutation('character.main.opacity', 0, { duration: 50 }),
       ]).then(result => {
         isResolved = true;
@@ -137,7 +137,7 @@ describe('RenderState', () => {
       renderState.run([
         new Mutation('character.main.opacity', 0.3),
         new Mutation('character.main.opacity', 0.9, { duration: 50 }),
-        new Mutation.Pause(100),
+        new Mutation.Delay(100),
         new Mutation('character.main.opacity', 0, { duration: 50 }),
       ]).then(result => {
         isResolved = true;

--- a/src/characterActions.js
+++ b/src/characterActions.js
@@ -105,7 +105,7 @@ const animateCharacter = (charName, character, fadeDuration, speed, delayBetween
     strokes: objRepeat({ opacity: 0 }, character.strokes.length),
   }, { force: true }));
   character.strokes.forEach((stroke, i) => {
-    if (i > 0) mutations.push(new Mutation.Pause(delayBetweenStrokes));
+    if (i > 0) mutations.push(new Mutation.Delay(delayBetweenStrokes));
     mutations = mutations.concat(animateStroke(charName, stroke, speed));
   });
   return mutations;
@@ -113,7 +113,7 @@ const animateCharacter = (charName, character, fadeDuration, speed, delayBetween
 
 const animateCharacterLoop = (charName, character, fadeDuration, speed, delayBetweenStrokes, delayBetweenLoops) => {
   const mutations = animateCharacter(charName, character, fadeDuration, speed, delayBetweenStrokes);
-  mutations.push(new Mutation.Pause(delayBetweenLoops));
+  mutations.push(new Mutation.Delay(delayBetweenLoops));
   return mutations;
 };
 


### PR DESCRIPTION
This PR adds a `writer.pauseAnimation()` method and `writer.resumeAnimation()` method. These will pause and resume any currently running animation, respectively.

Thanks @silent717120 for the feature request!

closes #155