### PR TITLE
fix: IE/Edge SVG animation bug

### DIFF
--- a/demo/test.js
+++ b/demo/test.js
@@ -15,10 +15,10 @@ function updateCharacter() {
 	writer = HanziWriter.create('target', character, {
 		width: 400,
 		height: 400,
-		renderer: 'canvas',
 		radicalColor: '#166E16',
 		onCorrectStroke: printStrokePoints,
 		onMistake: printStrokePoints,
+		showCharacter: false,
 	});
 	isCharVisible = true;
 	isOutlineVisible = true;

--- a/src/renderers/svg/CharacterRenderer.js
+++ b/src/renderers/svg/CharacterRenderer.js
@@ -1,3 +1,4 @@
+const { isMsBrowser } = require('../../utils');
 const StrokeRenderer = require('./StrokeRenderer');
 
 
@@ -18,10 +19,15 @@ CharacterRenderer.prototype.render = function(props) {
   if (props === this._oldProps) return;
   if (props.opacity !== this._oldProps.opacity) {
     this._group.style.opacity = props.opacity;
-    if (props.opacity === 0) {
-      this._group.style.display = 'none';
-    } else if (this._oldProps.opacity === 0) {
-      this._group.style.display = 'initial';
+    // MS browsers seem to have a bug where if SVG is set to display:none, it sometimes breaks.
+    // More info: https://github.com/chanind/hanzi-writer/issues/164
+    // this is just a perf improvement, so disable for MS browsers
+    if (!isMsBrowser) {
+      if (props.opacity === 0) {
+        this._group.style.display = 'none';
+      } else if (this._oldProps.opacity === 0) {
+        this._group.style.removeProperty('display');
+      }
     }
   }
   const colorsChanged = (

--- a/src/renderers/svg/__tests__/CharacterRenderer-test.js
+++ b/src/renderers/svg/__tests__/CharacterRenderer-test.js
@@ -123,7 +123,7 @@ describe('CharacterRenderer', () => {
     charRenderer.render(props2);
 
     expect(subCanvas.style.opacity).toBe('0.9');
-    expect(subCanvas.style.display).toBe('initial');
+    expect(subCanvas.style.display).toBe('');
   });
 
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,6 +120,9 @@ const objRepeat = (item, times) => {
   return obj;
 };
 
+const ua = (global.navigator && global.navigator.userAgent) || '';
+const isMsBrowser = ua.indexOf('MSIE ') > 0 || ua.indexOf('Trident/') > 0 || ua.indexOf('Edge/') > 0;
+
 module.exports = {
   _assign,
   arrLast,
@@ -137,4 +140,5 @@ module.exports = {
   requestAnimationFrame,
   timeout,
   trim,
+  isMsBrowser,
 };


### PR DESCRIPTION
This PR fixes an SVG animation bug in IE/Edge where the first stroke of the character just animates a tiny bit, but then the rest of the character animates correctly.

After further investigation, it seems like this bug only happens if the `<g>` tag of the SVG is set to `display:none` when the SVG is first rendered in the dom. If the SVG is later set to `display:none`, there's no issue. HanziWriter sets `display:none` as a performance optimization when a character layer has 0 opacity to keep the browser from trying to render the SVG at all, so this PR just removes that optimization for Microsoft browsers (IE and Edge).

Thanks to @bastianspirek for finding this bug!

fixes #164 