### PR TITLE
fix(Quiz) Don't highlight stroke when setting "showHintAfterMisses" to false

### DIFF
--- a/src/Quiz.js
+++ b/src/Quiz.js
@@ -69,7 +69,7 @@ Quiz.prototype.endUserStroke = function() {
     this._handleSuccess(currentStroke);
   } else {
     this._handleFailure();
-    if (this._numRecentMistakes >= this._options.showHintAfterMisses) {
+    if (this._numRecentMistakes >= this._options.showHintAfterMisses && this._options.showHintAfterMisses !== false) {
       this._renderState.run(
         quizActions.highlightStroke(currentStroke, this._options.highlightColor, this._options.strokeHighlightSpeed),
       );

--- a/src/__tests__/Quiz-test.js
+++ b/src/__tests__/Quiz-test.js
@@ -433,7 +433,7 @@ describe('Quiz', () => {
       await resolvePromises();
       expect(renderState.state.character.highlight.strokes[0].opacity).toBe(0);
     });
-    
+
     it('does not highlight strokes if showHintAfterMisses is set to false', async () => {
       strokeMatches.mockImplementation(() => false);
 

--- a/src/__tests__/Quiz-test.js
+++ b/src/__tests__/Quiz-test.js
@@ -433,6 +433,30 @@ describe('Quiz', () => {
       await resolvePromises();
       expect(renderState.state.character.highlight.strokes[0].opacity).toBe(0);
     });
+    
+    it('does not highlight strokes if showHintAfterMisses is set to false', async () => {
+      strokeMatches.mockImplementation(() => false);
+
+      const renderState = createRenderState();
+      // should reset this color before highlighting
+      renderState.state.character.highlight.strokeColor = '#00F';
+      const quiz = new Quiz(char, renderState, new Positioner());
+      const onCorrectStroke = jest.fn();
+      const onMistake = jest.fn();
+      const onComplete = jest.fn();
+      quiz.startQuiz(Object.assign({}, opts, { onCorrectStroke, onComplete, onMistake, showHintAfterMisses: false }));
+      clock.tick(1000);
+      await resolvePromises();
+
+      quiz.startUserStroke({x: 10, y: 20});
+      quiz.continueUserStroke({x: 11, y: 21});
+      quiz.endUserStroke();
+      await resolvePromises();
+      clock.tick(1000);
+      await resolvePromises();
+      // Stroke shouldn't be highlighted
+      expect(renderState.state.character.highlight.strokes[0].opacity).toBe(0);
+    });
 
     it('finishes the quiz when all strokes are successful', async () => {
       strokeMatches.mockImplementation(() => true);


### PR DESCRIPTION
The docs mention in multiple places that setting "showHintAfterMisses" to false will disable hint stroke highlighting. This isn't the case and instead highlights after every mistake. This commit fixes the issue.