### PR TITLE
update(HanziWriterRenderer) remove extra param on .mount() call

### DIFF
--- a/src/HanziWriter.js
+++ b/src/HanziWriter.js
@@ -227,7 +227,7 @@ HanziWriter.prototype.setCharacter = function(char) {
     this._renderState = new RenderState(this._character, this._options, (nextState) => {
       hanziWriterRenderer.render(nextState);
     });
-    this._hanziWriterRenderer.mount(this.target, this._renderState.state);
+    this._hanziWriterRenderer.mount(this.target);
     this._hanziWriterRenderer.render(this._renderState.state);
   });
   return this._withDataPromise;

--- a/src/renderers/svg/HanziWriterRenderer.js
+++ b/src/renderers/svg/HanziWriterRenderer.js
@@ -60,7 +60,7 @@ HanziWriterRenderer.prototype.render = function(props) {
     let strokeRenderer = this._userStrokeRenderers[userStrokeId];
     if (!strokeRenderer) {
       strokeRenderer = new UserStrokeRenderer();
-      strokeRenderer.mount(this._positionedTarget, userStrokeProps);
+      strokeRenderer.mount(this._positionedTarget);
       this._userStrokeRenderers[userStrokeId] = strokeRenderer;
     }
     strokeRenderer.render(userStrokeProps);

--- a/src/renderers/svg/__tests__/StrokeRenderer-test.js
+++ b/src/renderers/svg/__tests__/StrokeRenderer-test.js
@@ -25,7 +25,7 @@ describe('StrokeRenderer', () => {
     };
 
     const renderer = new StrokeRenderer(char.strokes[0]);
-    renderer.mount(target, props);
+    renderer.mount(target);
     renderer.render(props);
 
     expect(target.defs.childNodes.length).toBe(1);


### PR DESCRIPTION
`UserStrokeRenderer.prototype.mount(target)` and `(svg|canvas)/HanziWriterRenderer.prototype.mount(target)` do not have a second param on their function definitions, while some calls to these functions are invoking `.mount(target, props)`. It looks like the second parameter given to these functions are instead now used in a subsequent call to `xxxx.render(props)`