### PR TITLE
fix: support older node and browser versions

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,14 @@
 module.exports = {
   presets: [
     [
-      "@babel/preset-env",
+      '@babel/preset-env',
       {
         targets: {
-          node: "current",
+          browsers: '>2%',
+          node: '12',
         },
       },
     ],
-    "@babel/preset-typescript",
+    '@babel/preset-typescript',
   ],
 };


### PR DESCRIPTION
The current compile target for babel is the current node release, which is too modern. This PR changes the compile targets to target some older browsers and older node versions.

Hopefully this will fix #219 and fix #220