### PR TITLE
adding a getCharacterData() method for easier access to loaded character data

### DIFF
--- a/src/HanziWriter.ts
+++ b/src/HanziWriter.ts
@@ -419,6 +419,14 @@ export default class HanziWriter {
     return this._withDataPromise;
   }
 
+  async getCharacterData(): Promise<Character> {
+    if (!this._char) {
+      throw new Error('setCharacter() must be called before calling getCharacterData()');
+    }
+    const character = await this._withData(() => this._character);
+    return character!;
+  }
+
   _assignOptions(options: Partial<HanziWriterOptions>): ParsedHanziWriterOptions {
     const mergedOptions = {
       ...defaultOptions,


### PR DESCRIPTION
This PR adds a method `writer.getCharacterData()`, which returns a promise containing the parsed character data after it's loaded. This is to provide a more usable method to get info about the currently loaded character without needing to do anything hacky around reading internals like `writer._character`. This promise will always return the character data or error if it's not possible.

This character data contains the currently loaded character symbol (ex `我`), and an array of `strokes` containing the stroke data needed to render the character. This is probably most useful to determine how many strokes there are in the character.

related to #222