### PR TITLE
feat: allow checking backwards strokes

### DIFF
--- a/src/__tests__/Quiz-test.ts
+++ b/src/__tests__/Quiz-test.ts
@@ -278,7 +278,10 @@ describe('Quiz', () => {
 
   describe('endUserStroke', () => {
     it('finishes the stroke and moves on if it was correct', async () => {
-      (strokeMatches as any).mockImplementation(() => 'match');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: true,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -333,7 +336,10 @@ describe('Quiz', () => {
     });
 
     it('accepts backwards stroke when allowed', async () => {
-      (strokeMatches as any).mockImplementation(() => 'backwards-match');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: true },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -349,7 +355,7 @@ describe('Quiz', () => {
           onCorrectStroke,
           onComplete,
           onMistake,
-          checkBackwardsStrokes: 'accept',
+          acceptBackwardsStrokes: true,
         }),
       );
       clock.tick(1000);
@@ -395,7 +401,10 @@ describe('Quiz', () => {
     });
 
     it('notes backwards stroke when checking', async () => {
-      (strokeMatches as any).mockImplementation(() => 'backwards-match');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: true },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -411,7 +420,7 @@ describe('Quiz', () => {
           onCorrectStroke,
           onComplete,
           onMistake,
-          checkBackwardsStrokes: 'reject',
+          acceptBackwardsStrokes: false,
         }),
       );
       clock.tick(1000);
@@ -457,7 +466,10 @@ describe('Quiz', () => {
     });
 
     it('ignores single point strokes', async () => {
-      (strokeMatches as any).mockImplementation(() => 'miss');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -494,7 +506,10 @@ describe('Quiz', () => {
     });
 
     it('stays on the stroke if it was incorrect', async () => {
-      (strokeMatches as any).mockImplementation(() => 'miss');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -549,7 +564,10 @@ describe('Quiz', () => {
     });
 
     it('highlights the stroke if the number of mistakes exceeds showHintAfterMisses', async () => {
-      (strokeMatches as any).mockImplementation(() => 'miss');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -622,7 +640,10 @@ describe('Quiz', () => {
     });
 
     it('does not highlight strokes if showHintAfterMisses is set to false', async () => {
-      (strokeMatches as any).mockImplementation(() => 'miss');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: false,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -655,7 +676,10 @@ describe('Quiz', () => {
     });
 
     it('finishes the quiz when all strokes are successful', async () => {
-      (strokeMatches as any).mockImplementation(() => 'match');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: true,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -731,7 +755,10 @@ describe('Quiz', () => {
     });
 
     it('rounds drawn path data', async () => {
-      (strokeMatches as any).mockImplementation(() => 'match');
+      (strokeMatches as any).mockImplementation(() => ({
+        isMatch: true,
+        meta: { isStrokeBackwards: false },
+      }));
 
       const renderState = createRenderState();
       const quiz = new Quiz(
@@ -782,7 +809,10 @@ describe('Quiz', () => {
   });
 
   it('doesnt leave strokes partially drawn if the users finishes the quiz really fast', async () => {
-    (strokeMatches as any).mockImplementation(() => 'match');
+    (strokeMatches as any).mockImplementation(() => ({
+      isMatch: true,
+      meta: { isStrokeBackwards: false },
+    }));
     const renderState = createRenderState();
     const quiz = new Quiz(
       char,
@@ -815,7 +845,10 @@ describe('Quiz', () => {
   });
 
   it('sets up character opacities correctly if the users starts drawing during char fading', async () => {
-    (strokeMatches as any).mockImplementation(() => 'match');
+    (strokeMatches as any).mockImplementation(() => ({
+      isMatch: true,
+      meta: { isStrokeBackwards: false },
+    }));
     const renderState = createRenderState();
     const quiz = new Quiz(
       char,

--- a/src/__tests__/strokeMatches-test.ts
+++ b/src/__tests__/strokeMatches-test.ts
@@ -19,7 +19,7 @@ const assertMatches = (
 ) => {
   const char = getChar(charStr);
   const userStroke = { points } as any;
-  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe(true);
+  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe('match');
 };
 
 const assertNotMatches = (
@@ -30,7 +30,7 @@ const assertNotMatches = (
 ) => {
   const char = getChar(charStr);
   const userStroke = { points } as any;
-  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe(false);
+  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe('miss');
 };
 
 describe('strokeMatches', () => {
@@ -48,7 +48,7 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 10, y: 51 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe(true);
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('match');
   });
 
   it('does not match if the user stroke is in the wrong direction', () => {
@@ -65,7 +65,28 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 2, y: 1 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe(false);
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('miss');
+  });
+
+  it('identifies backwards stroke when allowed', () => {
+    const stroke = new Stroke(
+      '',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 50 },
+      ],
+      0,
+    );
+
+    const userStroke = new UserStroke(1, { x: 10, y: 51 }, { x: 9999, y: 9999 });
+    userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
+    userStroke.appendPoint({ x: 2, y: 1 }, { x: 9999, y: 9999 });
+
+    expect(
+      strokeMatches(userStroke, new Character('X', [stroke]), 0, {
+        checkBackwards: true,
+      }),
+    ).toBe('backwards-match');
   });
 
   it('does not match if the user stroke is too far away', () => {
@@ -86,7 +107,7 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5 + 200, y: 25 + 200 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 10 + 200, y: 51 + 200 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe(false);
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('miss');
   });
 
   it('is more lenient depending on how large leniency is', () => {
@@ -109,10 +130,10 @@ describe('strokeMatches', () => {
 
     expect(
       strokeMatches(userStroke, new Character('X', [stroke]), 0, { leniency: 0.2 }),
-    ).toBe(false);
+    ).toBe('miss');
     expect(
       strokeMatches(userStroke, new Character('X', [stroke]), 0, { leniency: 20 }),
-    ).toBe(true);
+    ).toBe('match');
   });
 
   it('matches using real data 1', () => {

--- a/src/__tests__/strokeMatches-test.ts
+++ b/src/__tests__/strokeMatches-test.ts
@@ -34,6 +34,21 @@ const assertNotMatches = (
 };
 
 describe('strokeMatches', () => {
+  it('does not match if the user stroke is a single point', () => {
+    const stroke = new Stroke(
+      '',
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 50 },
+      ],
+      0,
+    );
+
+    const userStroke = new UserStroke(1, { x: 2, y: 1 }, { x: 9999, y: 9999 });
+
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe(null);
+  });
+
   it('matches if the user stroke roughly matches the stroke medians', () => {
     const stroke = new Stroke(
       '',

--- a/src/__tests__/strokeMatches-test.ts
+++ b/src/__tests__/strokeMatches-test.ts
@@ -19,7 +19,7 @@ const assertMatches = (
 ) => {
   const char = getChar(charStr);
   const userStroke = { points } as any;
-  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe('match');
+  expect(strokeMatches(userStroke, char, strokeNum, options).isMatch).toBe(true);
 };
 
 const assertNotMatches = (
@@ -30,7 +30,7 @@ const assertNotMatches = (
 ) => {
   const char = getChar(charStr);
   const userStroke = { points } as any;
-  expect(strokeMatches(userStroke, char, strokeNum, options)).toBe('miss');
+  expect(strokeMatches(userStroke, char, strokeNum, options).isMatch).toBe(false);
 };
 
 describe('strokeMatches', () => {
@@ -46,7 +46,10 @@ describe('strokeMatches', () => {
 
     const userStroke = new UserStroke(1, { x: 2, y: 1 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe(null);
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toEqual({
+      isMatch: false,
+      meta: { isStrokeBackwards: false },
+    });
   });
 
   it('matches if the user stroke roughly matches the stroke medians', () => {
@@ -63,7 +66,10 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 10, y: 51 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('match');
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toEqual({
+      isMatch: true,
+      meta: { isStrokeBackwards: false },
+    });
   });
 
   it('does not match if the user stroke is in the wrong direction', () => {
@@ -80,28 +86,10 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 2, y: 1 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('miss');
-  });
-
-  it('identifies backwards stroke when allowed', () => {
-    const stroke = new Stroke(
-      '',
-      [
-        { x: 0, y: 0 },
-        { x: 10, y: 50 },
-      ],
-      0,
-    );
-
-    const userStroke = new UserStroke(1, { x: 10, y: 51 }, { x: 9999, y: 9999 });
-    userStroke.appendPoint({ x: 5, y: 25 }, { x: 9999, y: 9999 });
-    userStroke.appendPoint({ x: 2, y: 1 }, { x: 9999, y: 9999 });
-
-    expect(
-      strokeMatches(userStroke, new Character('X', [stroke]), 0, {
-        checkBackwards: true,
-      }),
-    ).toBe('backwards-match');
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toEqual({
+      isMatch: false,
+      meta: { isStrokeBackwards: true },
+    });
   });
 
   it('does not match if the user stroke is too far away', () => {
@@ -122,7 +110,10 @@ describe('strokeMatches', () => {
     userStroke.appendPoint({ x: 5 + 200, y: 25 + 200 }, { x: 9999, y: 9999 });
     userStroke.appendPoint({ x: 10 + 200, y: 51 + 200 }, { x: 9999, y: 9999 });
 
-    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toBe('miss');
+    expect(strokeMatches(userStroke, new Character('X', [stroke]), 0)).toEqual({
+      isMatch: false,
+      meta: { isStrokeBackwards: false },
+    });
   });
 
   it('is more lenient depending on how large leniency is', () => {
@@ -145,10 +136,10 @@ describe('strokeMatches', () => {
 
     expect(
       strokeMatches(userStroke, new Character('X', [stroke]), 0, { leniency: 0.2 }),
-    ).toBe('miss');
+    ).toEqual({ isMatch: false, meta: { isStrokeBackwards: false } });
     expect(
       strokeMatches(userStroke, new Character('X', [stroke]), 0, { leniency: 20 }),
-    ).toBe('match');
+    ).toEqual({ isMatch: true, meta: { isStrokeBackwards: false } });
   });
 
   it('matches using real data 1', () => {

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -38,7 +38,7 @@ const defaultOptions: HanziWriterOptions = {
   showHintAfterMisses: 3,
   highlightOnComplete: true,
   highlightCompleteColor: null,
-  checkBackwardsStrokes: false,
+  acceptBackwardsStrokes: false,
 
   // undocumented obscure options
 

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -38,6 +38,7 @@ const defaultOptions: HanziWriterOptions = {
   showHintAfterMisses: 3,
   highlightOnComplete: true,
   highlightCompleteColor: null,
+  checkBackwardsStrokes: false,
 
   // undocumented obscure options
 

--- a/src/strokeMatches.ts
+++ b/src/strokeMatches.ts
@@ -20,6 +20,8 @@ const START_AND_END_DIST_THRESHOLD = 250; // bigger = more lenient
 const FRECHET_THRESHOLD = 0.4; // bigger = more lenient
 const MIN_LEN_THRESHOLD = 0.35; // smaller = more lenient
 
+export type StrokeMatchType = 'miss' | 'match' | 'backwards-match';
+
 export default function strokeMatches(
   userStroke: UserStroke,
   character: Character,
@@ -27,8 +29,9 @@ export default function strokeMatches(
   options: {
     leniency?: number;
     isOutlineVisible?: boolean;
+    checkBackwards?: boolean;
   } = {},
-) {
+): StrokeMatchType | null {
   const strokes = character.strokes;
   const points = stripDuplicates(userStroke.points);
 
@@ -36,10 +39,14 @@ export default function strokeMatches(
     return null;
   }
 
-  const { isMatch, avgDist } = getMatchData(points, strokes[strokeNum], options);
+  const { isMatch, isBackwards, avgDist } = getMatchData(
+    points,
+    strokes[strokeNum],
+    options,
+  );
 
   if (!isMatch) {
-    return false;
+    return getMatchType({ isMatch, isBackwards });
   }
 
   // if there is a better match among strokes the user hasn't drawn yet, the user probably drew the wrong stroke
@@ -47,7 +54,10 @@ export default function strokeMatches(
   let closestMatchDist = avgDist;
 
   for (let i = 0; i < laterStrokes.length; i++) {
-    const { isMatch, avgDist } = getMatchData(points, laterStrokes[i], options);
+    const { isMatch, avgDist } = getMatchData(points, laterStrokes[i], {
+      ...options,
+      checkBackwards: false,
+    });
     if (isMatch && avgDist < closestMatchDist) {
       closestMatchDist = avgDist;
     }
@@ -57,14 +67,26 @@ export default function strokeMatches(
   if (closestMatchDist < avgDist) {
     // adjust leniency between 0.3 and 0.6 depending on how much of a better match the new match is
     const leniencyAdjustment = (0.6 * (closestMatchDist + avgDist)) / (2 * avgDist);
-    const { isMatch } = getMatchData(points, strokes[strokeNum], {
+    const matchData = getMatchData(points, strokes[strokeNum], {
       ...options,
       leniency: (options.leniency || 1) * leniencyAdjustment,
     });
-    return isMatch;
+    return getMatchType(matchData);
   }
-  return true;
+  return getMatchType({ isMatch, isBackwards });
 }
+
+const getMatchType = ({
+  isMatch,
+  isBackwards,
+}: {
+  isMatch: boolean;
+  isBackwards: boolean;
+}): StrokeMatchType => {
+  if (isBackwards) return 'backwards-match';
+  if (isMatch) return 'match';
+  return 'miss';
+};
 
 const startAndEndMatches = (points: Point[], closestStroke: Stroke, leniency: number) => {
   const startingDist = distance(closestStroke.getStartingPoint(), points[0]);
@@ -143,23 +165,37 @@ const shapeFit = (curve1: Point[], curve2: Point[], leniency: number) => {
 const getMatchData = (
   points: Point[],
   stroke: Stroke,
-  options: { leniency?: number; isOutlineVisible?: boolean },
+  options: { leniency?: number; isOutlineVisible?: boolean; checkBackwards?: boolean },
 ) => {
-  const { leniency = 1, isOutlineVisible = false } = options;
+  const { leniency = 1, isOutlineVisible = false, checkBackwards = false } = options;
   const avgDist = stroke.getAverageDistance(points);
   const distMod = isOutlineVisible || stroke.strokeNum > 0 ? 0.5 : 1;
   const withinDistThresh = avgDist <= AVG_DIST_THRESHOLD * distMod * leniency;
   // short circuit for faster matching
   if (!withinDistThresh) {
-    return { isMatch: false, avgDist };
+    return { isMatch: false, isBackwards: false, avgDist };
   }
   const startAndEndMatch = startAndEndMatches(points, stroke, leniency);
   const directionMatch = directionMatches(points, stroke);
   const shapeMatch = shapeFit(points, stroke.points, leniency);
   const lengthMatch = lengthMatches(points, stroke, leniency);
-  return {
-    isMatch:
-      withinDistThresh && startAndEndMatch && directionMatch && shapeMatch && lengthMatch,
-    avgDist,
-  };
+
+  const isMatch =
+    withinDistThresh && startAndEndMatch && directionMatch && shapeMatch && lengthMatch;
+
+  if (checkBackwards && !isMatch) {
+    const backwardsMatchData = getMatchData([...points].reverse(), stroke, {
+      ...options,
+      checkBackwards: false,
+    });
+
+    if (backwardsMatchData.isMatch) {
+      return {
+        ...backwardsMatchData,
+        isBackwards: true,
+      };
+    }
+  }
+
+  return { isMatch, isBackwards: false, avgDist };
 };

--- a/src/strokeMatches.ts
+++ b/src/strokeMatches.ts
@@ -166,7 +166,7 @@ const getMatchData = (
   points: Point[],
   stroke: Stroke,
   options: { leniency?: number; isOutlineVisible?: boolean; checkBackwards?: boolean },
-) => {
+): { isMatch: boolean; isBackwards: boolean; avgDist: number } => {
   const { leniency = 1, isOutlineVisible = false, checkBackwards = false } = options;
   const avgDist = stroke.getAverageDistance(points);
   const distMod = isOutlineVisible || stroke.strokeNum > 0 ? 0.5 : 1;

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -52,6 +52,7 @@ export type StrokeData = {
     pathString: string;
     points: Point[];
   };
+  isBackwards: boolean;
   strokeNum: number;
   mistakesOnStroke: number;
   totalMistakes: number;
@@ -65,6 +66,8 @@ export type QuizOptions = {
   showHintAfterMisses: number | false;
   /** After a quiz is completed successfully, the character will flash briefly. Default: true */
   highlightOnComplete: boolean;
+  /** Whether to check if strokes are correct besides their direction. When checking, backwards strokes can be considered correct (`'accept'`) or incorrect (`'reject'`). */
+  checkBackwardsStrokes?: 'accept' | 'reject' | false;
   onMistake?: (strokeData: StrokeData) => void;
   onCorrectStroke?: (strokeData: StrokeData) => void;
   /** Callback when the quiz completes */

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -66,8 +66,8 @@ export type QuizOptions = {
   showHintAfterMisses: number | false;
   /** After a quiz is completed successfully, the character will flash briefly. Default: true */
   highlightOnComplete: boolean;
-  /** Whether to check if strokes are correct besides their direction. When checking, backwards strokes can be considered correct (`'accept'`) or incorrect (`'reject'`). */
-  checkBackwardsStrokes?: 'accept' | 'reject' | false;
+  /** Whether to treat strokes which are correct besides their direction as correct. */
+  acceptBackwardsStrokes: boolean;
   onMistake?: (strokeData: StrokeData) => void;
   onCorrectStroke?: (strokeData: StrokeData) => void;
   /** Callback when the quiz completes */


### PR DESCRIPTION
The use case for this is to allow applications to notify a user when they make a backwards stroke (one which is correct except for the direction in which in which it's made) on a quiz. In such a case, the application will likely want to show some messaging to the user indicating the stroke was made in the wrong direction. The application may want to treat backwards strokes as correct or incorrect.

This change includes two API changes to fulfill the above use case:
- The addition of a `checkBackwardsStrokes` ternary quiz option (defaulted off)
- The `onCorrectStroke` and `onMistake` quiz handlers receive an `isBackwards` boolean property on the stroke data.

`checkBackwardsStrokes` is ternary to allow avoiding the perf hit of checking backwards strokes if the application does not care about them.

If `checkBackwardsStrokes` is `false`, the handlers will always receive `isBackwards: false` since the backwards check is skipped. The alternative here is to return e.g. `null` if the check was skipped. I opted against this to keep the API a bit simpler with a consistent type for `isBackwards`.