### PR TITLE
fix: prevent possible delay page scrolling marking touch listeners as passive

### DIFF
--- a/src/renderers/RenderTargetBase.ts
+++ b/src/renderers/RenderTargetBase.ts
@@ -25,7 +25,7 @@ export default class RenderTargetBase<
     });
     this.node.addEventListener('touchstart', (evt) => {
       callback(this._eventify(evt as TouchEvent, this._getTouchPoint));
-    });
+    }, {passive: true});
   }
 
   addPointerMoveListener(callback: (arg: BoundEvent) => void) {
@@ -34,7 +34,7 @@ export default class RenderTargetBase<
     });
     this.node.addEventListener('touchmove', (evt) => {
       callback(this._eventify(evt as TouchEvent, this._getTouchPoint));
-    });
+    }, {passive: true});
   }
 
   addPointerEndListener(callback: () => void) {


### PR DESCRIPTION
Lighthouse passive event listener audit fails (https://web.dev/uses-passive-event-listeners/?utm_source=lighthouse&utm_medium=lr#how-the-lighthouse-passive-event-listener-audit-fails)
[Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) flags event listeners that may delay page scrolling. 

Improved scrolling performance by adding a passive flag to every event listener that Lighthouse identified.