### PR TITLE
fix: hide stroke highlight if it gets canceled

### DIFF
--- a/src/characterActions.ts
+++ b/src/characterActions.ts
@@ -84,7 +84,10 @@ export const highlightStroke = (
       },
       { duration },
     ),
-    new Mutation(`character.highlight.strokes.${strokeNum}.opacity`, 0, { duration }),
+    new Mutation(`character.highlight.strokes.${strokeNum}.opacity`, 0, {
+      duration,
+      force: true,
+    }),
   ];
 };
 


### PR DESCRIPTION
Currently, if a stroke highlight animation gets interrupted it just leaves the stroke highlight in whatever state it's in mid-animation. This PR fixes this to force the highlight to disappear when it gets interrupted rather than hanging around looking strange. Thank you to @GnitLores for finding this!

fixes #292