### PR TITLE
feat: adding markStrokeCorrectAfterMisses option to quizzes

### DIFF
--- a/demo/test.js
+++ b/demo/test.js
@@ -17,7 +17,6 @@ function updateCharacter() {
     height: 400,
     renderer: 'svg',
     radicalColor: '#166E16',
-    highlightCompleteColor: '#FF0000',
     onCorrectStroke: printStrokePoints,
     onMistake: printStrokePoints,
     showCharacter: false,

--- a/src/Quiz.ts
+++ b/src/Quiz.ts
@@ -100,7 +100,7 @@ export default class Quiz {
       return;
     }
 
-    const { acceptBackwardsStrokes } = this._options!;
+    const { acceptBackwardsStrokes, markStrokeCorrectAfterMisses } = this._options!;
 
     const currentStroke = this._getCurrentStroke();
     const { isMatch, meta } = strokeMatches(
@@ -113,7 +113,13 @@ export default class Quiz {
       },
     );
 
-    const isAccepted = isMatch || (meta.isStrokeBackwards && acceptBackwardsStrokes);
+    // if markStrokeCorrectAfterMisses is passed, just force the stroke to count as correct after n tries
+    const isForceAccepted =
+      markStrokeCorrectAfterMisses &&
+      this._mistakesOnStroke + 1 >= markStrokeCorrectAfterMisses;
+
+    const isAccepted =
+      isMatch || isForceAccepted || (meta.isStrokeBackwards && acceptBackwardsStrokes);
 
     if (isAccepted) {
       this._handleSuccess(meta);

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -38,6 +38,7 @@ const defaultOptions: HanziWriterOptions = {
   showHintAfterMisses: 3,
   highlightOnComplete: true,
   highlightCompleteColor: null,
+  markStrokeCorrectAfterMisses: false,
   acceptBackwardsStrokes: false,
   quizStartStrokeNum: 0,
 

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -70,6 +70,8 @@ export type QuizOptions = {
   acceptBackwardsStrokes: boolean;
   /** Begin quiz on this stroke number rather than stroke 0 */
   quizStartStrokeNum: number;
+  /** After a user makes this many mistakes, just mark the stroke correct and move on. Default: false */
+  markStrokeCorrectAfterMisses: number | false;
   onMistake?: (strokeData: StrokeData) => void;
   onCorrectStroke?: (strokeData: StrokeData) => void;
   /** Callback when the quiz completes */


### PR DESCRIPTION
This PR adds a `markStrokeCorrectAfterMisses` option to `new HanziWriter()` and `HanziWriter.quiz()` which allows setting a number of mistakes after which the users's stroke will be marked correct no matter what. Thank you to @ ganqqwerty for the feature suggestion!

closes #289