### PR TITLE
feat: add onCancel option to quizzes

### DIFF
--- a/src/Quiz.ts
+++ b/src/Quiz.ts
@@ -157,6 +157,16 @@ export default class Quiz {
         ),
       );
     }
+
+    if (!this._options) return;
+
+    const { symbol } = this._character;
+    const { onCancel } = this._options;
+
+    onCancel?.({
+      character: symbol,
+      totalMistakes: this._totalMistakes,
+    });
   }
 
   _getStrokeData({

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -78,6 +78,8 @@ export type QuizOptions = {
   onCorrectStroke?: (strokeData: StrokeData) => void;
   /** Callback when the quiz completes */
   onComplete?: (summary: { character: string; totalMistakes: number }) => void;
+  /** Callback when the quiz got canceled */
+  onCancel?: (summary: { character: string; totalMistakes: number }) => void;
 };
 
 export type LoadingManagerOptions = {


### PR DESCRIPTION
With this pr I want to add the callback onCancel to the options of quiz objects. This callback is executed whenever the quiz is cancelled. I gave it the same type as onComplete:
```
  onCancel?: (summary: { character: string; totalMistakes: number }) => void;
```

All tests have passed on my machine.