### PR TITLE
feat: Added skipStrokeQuiz

### DIFF
--- a/src/HanziWriter.ts
+++ b/src/HanziWriter.ts
@@ -405,6 +405,12 @@ export default class HanziWriter {
     });
   }
 
+  skipStrokeQuiz() {
+    if (this._quiz) {
+      this._quiz._showNextStroke();
+    }
+  }
+
   cancelQuiz() {
     if (this._quiz) {
       this._quiz.cancel();

--- a/src/HanziWriter.ts
+++ b/src/HanziWriter.ts
@@ -405,9 +405,9 @@ export default class HanziWriter {
     });
   }
 
-  skipStrokeQuiz() {
+  skipQuizStroke() {
     if (this._quiz) {
-      this._quiz._showNextStroke();
+      this._quiz.nextStroke();
     }
   }
 

--- a/src/Quiz.ts
+++ b/src/Quiz.ts
@@ -127,8 +127,11 @@ export default class Quiz {
     } else {
       this._handleFailure(meta);
 
-      const { showHintAfterMisses, highlightColor, strokeHighlightSpeed } =
-        this._options!;
+      const {
+        showHintAfterMisses,
+        highlightColor,
+        strokeHighlightSpeed,
+      } = this._options!;
 
       if (
         showHintAfterMisses !== false &&
@@ -178,7 +181,7 @@ export default class Quiz {
     };
   }
 
-  _showNextStroke() {
+  nextStroke() {
     if (!this._options) return;
 
     const { strokes, symbol } = this._character;
@@ -232,7 +235,7 @@ export default class Quiz {
       ...this._getStrokeData({ isCorrect: true, meta }),
     });
 
-    this._showNextStroke();
+    this.nextStroke();
   }
 
   _handleFailure(meta: StrokeMatchResultMeta) {

--- a/src/Quiz.ts
+++ b/src/Quiz.ts
@@ -178,13 +178,12 @@ export default class Quiz {
     };
   }
 
-  _handleSuccess(meta: StrokeMatchResultMeta) {
+  _showNextStroke() {
     if (!this._options) return;
 
     const { strokes, symbol } = this._character;
 
     const {
-      onCorrectStroke,
       onComplete,
       highlightOnComplete,
       strokeFadeDuration,
@@ -192,10 +191,6 @@ export default class Quiz {
       highlightColor,
       strokeHighlightDuration,
     } = this._options;
-
-    onCorrectStroke?.({
-      ...this._getStrokeData({ isCorrect: true, meta }),
-    });
 
     let animation: GenericMutation[] = characterActions.showStroke(
       'main',
@@ -226,6 +221,18 @@ export default class Quiz {
     }
 
     this._renderState.run(animation);
+  }
+
+  _handleSuccess(meta: StrokeMatchResultMeta) {
+    if (!this._options) return;
+
+    const { onCorrectStroke } = this._options;
+
+    onCorrectStroke?.({
+      ...this._getStrokeData({ isCorrect: true, meta }),
+    });
+
+    this._showNextStroke();
   }
 
   _handleFailure(meta: StrokeMatchResultMeta) {

--- a/src/__tests__/HanziWriter-test.ts
+++ b/src/__tests__/HanziWriter-test.ts
@@ -1140,6 +1140,27 @@ describe('HanziWriter', () => {
     });
   });
 
+  describe('skipQuizStroke', () => {
+    it('returns if there is not active quiz', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+      const writer = HanziWriter.create('target', '人', { charDataLoader });
+      await writer._withDataPromise;
+      expect(writer.skipQuizStroke()).toBe(undefined);
+      expect(writer._quiz).toBe(undefined);
+    });
+
+    it('skips the current stroke if a quiz is active', async () => {
+      document.body.innerHTML = '<div id="target"></div>';
+      const writer = HanziWriter.create('target', '人', { charDataLoader });
+      writer.quiz();
+      await resolvePromises();
+      const quiz = writer._quiz!;
+      writer.skipQuizStroke();
+      expect(quiz.nextStroke).toHaveBeenCalledTimes(1);
+      expect(quiz._handleSuccess).not.toHaveBeenCalled();
+    });
+  });
+
   describe('mouse and touch events', () => {
     let writer: HanziWriter;
     beforeEach(async () => {

--- a/src/__tests__/Quiz-test.ts
+++ b/src/__tests__/Quiz-test.ts
@@ -956,6 +956,40 @@ describe('Quiz', () => {
     });
   });
 
+  describe('nextStroke', () => {
+    it('shows the current stroke and moves to the next stroke', async () => {
+      const renderState = createRenderState();
+      const quiz = new Quiz(
+        char,
+        renderState,
+        new Positioner({ padding: 20, width: 200, height: 200 }),
+      );
+      const onCorrectStroke = jest.fn();
+      const onMistake = jest.fn();
+      const onComplete = jest.fn();
+      quiz.startQuiz(Object.assign({}, opts, { onCorrectStroke, onComplete, onMistake }));
+      clock.tick(1000);
+      await resolvePromises();
+
+      expect(quiz._currentStrokeIndex).toBe(0);
+      quiz.nextStroke();
+      await resolvePromises();
+
+      expect(quiz._userStroke).toBeUndefined();
+      expect(quiz._isActive).toBe(true);
+      expect(quiz._currentStrokeIndex).toBe(1);
+      expect(onCorrectStroke).not.toHaveBeenCalled();
+      expect(onMistake).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      clock.tick(1000);
+      await resolvePromises();
+
+      expect(renderState.state.character.main.strokes[0].opacity).toBe(1);
+      expect(renderState.state.character.main.strokes[1].opacity).toBe(0);
+    });
+  });
+
   it('doesnt leave strokes partially drawn if the users finishes the quiz really fast', async () => {
     (strokeMatches as any).mockImplementation(() => ({
       isMatch: true,


### PR DESCRIPTION
This feature adds a function skipStrokeQuiz, that can be used while in a quiz to skip a stroke. This is useful for e.g. 圖, since hanzi writer has a hard time recognizing the short strike under the upper inner box of
![clipboard](https://github.com/chanind/hanzi-writer/assets/50072577/a34019a2-44d2-412a-ac65-d0cfeab8f50e)


