### PR TITLE
Fix: TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,9 +6,10 @@ const globalObj = typeof window === 'undefined' ? global : window;
 export const performanceNow =
   (globalObj.performance && (() => globalObj.performance.now())) || (() => Date.now());
 export const requestAnimationFrame =
-  globalObj.requestAnimationFrame ||
+  globalObj.requestAnimationFrame?.bind(globalObj) ||
   ((callback) => setTimeout(() => callback(performanceNow()), 1000 / 60));
-export const cancelAnimationFrame = globalObj.cancelAnimationFrame || clearTimeout;
+export const cancelAnimationFrame =
+  globalObj.cancelAnimationFrame?.bind(globalObj) || clearTimeout;
 
 // Object.assign polyfill, because IE :/
 export const _assign = function (target: any, ...overrides: any[]) {


### PR DESCRIPTION
On Firefox 132.0.1 (aarch64) on macOS, I get this error:

`TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window.` (from `Mutation.ts` line 134)
And the same error for `cancelAnimationFrame`

I don't get that error on Safari or Chrome on the same machine.

Binding them to the global object fixes that error for me.
