### PR TITLE
Use full semver (hanzi-writer-data@2.0.1) to take advantage of Cache-Control

### DIFF
--- a/src/__tests__/defaultCharDataLoader-test.ts
+++ b/src/__tests__/defaultCharDataLoader-test.ts
@@ -26,7 +26,7 @@ describe('defaultCharDataLoader', () => {
 
     expect(requests.length).toBe(1);
     expect(requests[0].url).toBe(
-      'https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/人.json',
+      'https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0.1/人.json',
     );
 
     requests[0].respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(ren));
@@ -44,7 +44,7 @@ describe('defaultCharDataLoader', () => {
 
     expect(requests.length).toBe(1);
     expect(requests[0].url).toBe(
-      'https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/Q.json',
+      'https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0.1/Q.json',
     );
 
     requests[0].respond(

--- a/src/defaultCharDataLoader.ts
+++ b/src/defaultCharDataLoader.ts
@@ -1,6 +1,6 @@
 import { CharacterJson } from './typings/types';
 
-const VERSION = '2.0';
+const VERSION = '2.0.1';
 const getCharDataUrl = (char: string) =>
   `https://cdn.jsdelivr.net/npm/hanzi-writer-data@${VERSION}/${char}.json`;
 


### PR DESCRIPTION
Currently, if you `fetch("https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0/人.json")`, the Cache-Control duration from  jsdelivr is only 604,800 seconds; i.e., after one week, the user's browser will evict its cache of the character's json. This is because the version "2.0" is not full semver, so jsdelivr needs to resolve "2.0" to "2.0.1".

<img width="684" height="435" alt="image" src="https://github.com/user-attachments/assets/96683d79-ad54-4bd5-b976-6cc950b1df92" />

This PR makes the fetch instead point to "2.0.1", e.g. `fetch("https://cdn.jsdelivr.net/npm/hanzi-writer-data@2.0.1/人.json")`. (This can always be bumped as needed.) The advantage however is that because npm packages with fully-qualified semver versions are considered immutable, jsdelivr instead gives a Cache-Control length of 31,536,000 seconds, i.e. the JSON for each character can stay cached in the user's browser for a full year.
<img width="648" height="435" alt="image" src="https://github.com/user-attachments/assets/f573e67f-ab94-4ea5-a130-9d91a90ceb8b" />
